### PR TITLE
fix: preserve multiline/quoted commands in daemon exec

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 	"syscall"
 
 	"github.com/charmbracelet/log"
@@ -18,15 +17,13 @@ import (
 func ExecMiddleware(tracker *ProcessTracker) wish.Middleware {
 	return func(next ssh.Handler) ssh.Handler {
 		return func(sess ssh.Session) {
-			cmd := sess.Command()
+			cmdStr := sess.RawCommand()
 
 			// No command — interactive PTY shell
-			if len(cmd) == 0 {
+			if cmdStr == "" {
 				handlePTY(sess, tracker)
 				return
 			}
-
-			cmdStr := strings.Join(cmd, " ")
 
 			// Health check command
 			if cmdStr == "__aiope_health__" {


### PR DESCRIPTION
## The bug

`ssh_exec` mangles any command with quotes, newlines, or multi-space formatting. Symptom trail from real sessions:

```
sh: 1: Syntax error: "(" unexpected        ← awk '{print $1}' lost its quotes
sh: 2: import: not found                   ← multi-line python -c collapsed to one line
sh: 1: Syntax error: Unterminated quoted string  ← heredocs collapsed
```

## Root cause

`daemon/exec.go`:

```go
cmd := sess.Command()            // charmbracelet tokenizes on whitespace, quote-UNaware
cmdStr := strings.Join(cmd, " ") // rejoins with single spaces → destroys newlines/quotes/spacing
```

`ssh.Session.Command()` returns `strings.Fields(raw)` — it splits on whitespace without honoring quotes. Rejoining can never recover the original.

## Fix

Use `sess.RawCommand()` — the exact string sent over the wire — and pass it straight to `sh -c`:

```go
cmdStr := sess.RawCommand()
if cmdStr == "" {
    handlePTY(sess, tracker)
    return
}
```

Also drops the now-unused `strings` import.

## Verified

- Client (`SshSessionManager.exec` line 141) sends the raw command via SSHJ `session.exec(command)` — untouched. The daemon was the only mangler.
- The bug reproduced itself live during diagnosis: `grep -n "\.Command("` failed with `Syntax error: "(" unexpected`.
- PTY/health paths unchanged (`__aiope_health__` still exact-matches via RawCommand).

After merge: rebuild + redeploy the daemon binary on build + production wg hosts.