### PR TITLE
Fix and expand conversation sharing feature

### DIFF
--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -3,4 +3,5 @@
   <cache-path name="cache" path="." />
   <files-path name="files" path="." />
   <external-path name="external" path="." />
+  <cache-path name="shared_files" path="share/" />
 </paths>

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatScreen.kt
@@ -56,7 +56,9 @@ fun ChatScreen(viewModel: ChatViewModel = hiltViewModel(), onOpenSettings: () ->
   val isLandscape = config.screenWidthDp > config.screenHeightDp
   var showModelPicker by remember { mutableStateOf(false) }
   var showConversations by remember { mutableStateOf(false) }
+  var showShareSheet by remember { mutableStateOf(false) }
   var editText by remember { mutableStateOf("") }
+  val context = androidx.compose.ui.platform.LocalContext.current
 
   @OptIn(ExperimentalLayoutApi::class)
   val imeVisible = WindowInsets.isImeVisible
@@ -82,7 +84,7 @@ fun ChatScreen(viewModel: ChatViewModel = hiltViewModel(), onOpenSettings: () ->
           onGetModels = { viewModel.getModelList() }, onGetActiveModelId = { viewModel.providerStore.getActive().selectedModelId },
           onSwitchModel = { viewModel.switchModel(it) },
           onChats = { showConversations = true },
-          onShareChat = { viewModel.shareConversation() },
+          onShareChat = { showShareSheet = true },
           onEditMessage = { text, idx ->
             viewModel.truncateAt(idx)
             editText = text
@@ -144,7 +146,7 @@ fun ChatScreen(viewModel: ChatViewModel = hiltViewModel(), onOpenSettings: () ->
           onGetModels = { viewModel.getModelList() }, onGetActiveModelId = { viewModel.providerStore.getActive().selectedModelId },
           onSwitchModel = { viewModel.switchModel(it) },
           onChats = { showConversations = true },
-          onShareChat = { viewModel.shareConversation() },
+          onShareChat = { showShareSheet = true },
           onEditMessage = { text, idx ->
             viewModel.truncateAt(idx)
             editText = text
@@ -189,6 +191,16 @@ fun ChatScreen(viewModel: ChatViewModel = hiltViewModel(), onOpenSettings: () ->
   }
 
   if (showConversations) ConversationSheet(viewModel, onDismiss = { showConversations = false })
+
+  if (showShareSheet) {
+    ShareFormatSheet(
+      onDismissRequest = { showShareSheet = false },
+      onFormatSelected = { format ->
+        showShareSheet = false
+        viewModel.shareConversation(format, context)
+      }
+    )
+  }
 }
 
 // ── Main chat content ──

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatViewModel.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatViewModel.kt
@@ -372,47 +372,92 @@ class ChatViewModel @Inject constructor(
     }
   }
 
-  fun shareConversation(asJson: Boolean = false) {
+  fun getConversationContent(format: String): String {
     val msgs = _messages.value
-    if (msgs.isEmpty()) return
-    val ctx = getApplication<android.app.Application>()
-    val (text, mime) = if (asJson) {
-      val arr = org.json.JSONArray()
-      msgs.forEach { m ->
-        arr.put(
-          org.json.JSONObject().put("role", m.role.value).put("content", m.content)
-            .apply { if (m.toolCalls.isNotEmpty()) put("tool_calls", org.json.JSONArray(m.toolCalls)) },
-        )
-      }
-      org.json.JSONObject().put("title", conversationId).put("exported", System.currentTimeMillis()).put("messages", arr).toString(2) to "application/json"
-    } else {
-      val md = buildString {
-        append("# AIOPE Conversation\n\n")
+    if (msgs.isEmpty()) return ""
+    return when (format) {
+      "json" -> {
+        val arr = org.json.JSONArray()
         msgs.forEach { m ->
-          when (m.role) {
-            Role.USER -> append("## User\n\n${m.content}\n\n")
-            Role.ASSISTANT -> append("## Assistant\n\n${m.content}\n\n")
-            Role.SYSTEM -> append("> _System: ${m.content.take(200)}_\n\n")
-            else -> append("## ${m.role.value}\n\n${m.content}\n\n")
-          }
-          if (m.toolCalls.isNotEmpty()) {
-            append("<details><summary>Tools used</summary>\n\n")
-            m.toolCalls.forEachIndexed { i, call ->
-              val result = m.toolResults.getOrNull(i)?.take(300) ?: ""
-              append("- `$call`\n  → $result\n")
+          arr.put(
+            org.json.JSONObject().put("role", m.role.value).put("content", m.content)
+              .apply { if (m.toolCalls.isNotEmpty()) put("tool_calls", org.json.JSONArray(m.toolCalls)) }
+          )
+        }
+        org.json.JSONObject().put("title", conversationId).put("exported", System.currentTimeMillis()).put("messages", arr).toString(2)
+      }
+      "txt" -> {
+        buildString {
+          msgs.forEach { m ->
+            when (m.role) {
+              Role.USER -> append("User: ${m.content}\n\n")
+              Role.ASSISTANT -> append("Assistant: ${m.content}\n\n")
+              Role.SYSTEM -> append("System: ${m.content.take(200)}\n\n")
+              else -> append("${m.role.value}: ${m.content}\n\n")
             }
-            append("\n</details>\n\n")
           }
         }
       }
-      md to "text/markdown"
+      else -> { // markdown and pdf use the same base content
+        buildString {
+          append("# AIOPE Conversation\n\n")
+          msgs.forEach { m ->
+            when (m.role) {
+              Role.USER -> append("## User\n\n${m.content}\n\n")
+              Role.ASSISTANT -> append("## Assistant\n\n${m.content}\n\n")
+              Role.SYSTEM -> append("> _System: ${m.content.take(200)}_\n\n")
+              else -> append("## ${m.role.value}\n\n${m.content}\n\n")
+            }
+            if (m.toolCalls.isNotEmpty()) {
+              append("<details><summary>Tools used</summary>\n\n")
+              m.toolCalls.forEachIndexed { i, call ->
+                val result = m.toolResults.getOrNull(i)?.take(300) ?: ""
+                append("- `$call`\n  → $result\n")
+              }
+              append("\n</details>\n\n")
+            }
+          }
+        }
+      }
     }
-    val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
-      type = "text/plain"
-      putExtra(android.content.Intent.EXTRA_TEXT, text)
-      putExtra(android.content.Intent.EXTRA_SUBJECT, "AIOPE Conversation")
+  }
+
+  fun shareConversation(format: String, context: android.content.Context) {
+    val content = getConversationContent(format)
+    if (content.isEmpty()) return
+
+    if (format == "pdf") {
+       LatexPdfExporter.export(context, content)
+       return
     }
-    ctx.startActivity(android.content.Intent.createChooser(intent, "Share conversation").addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK))
+
+    viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+      try {
+        val shareDir = java.io.File(context.cacheDir, "share")
+        if (!shareDir.exists()) shareDir.mkdirs()
+        val file = java.io.File(shareDir, "aiope_export_${System.currentTimeMillis()}.$format")
+        file.writeText(content)
+
+        val uri = androidx.core.content.FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+        val mimeType = when (format) {
+           "json" -> "application/json"
+           "md" -> "text/markdown"
+           else -> "text/plain"
+        }
+
+        val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+          type = mimeType
+          putExtra(android.content.Intent.EXTRA_STREAM, uri)
+          addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+          context.startActivity(android.content.Intent.createChooser(intent, "Share conversation"))
+        }
+      } catch (e: Exception) {
+        e.printStackTrace()
+      }
+    }
   }
   fun deleteConversation(id: String) {
     viewModelScope.launch {

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ShareFormatSheet.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ShareFormatSheet.kt
@@ -1,0 +1,99 @@
+package ngo.xnet.aiope.feature.chat
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.PictureAsPdf
+import androidx.compose.material.icons.filled.TextFields
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ShareFormatSheet(
+    onDismissRequest: () -> Unit,
+    onFormatSelected: (String) -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        dragHandle = { BottomSheetDefaults.DragHandle() },
+        containerColor = MaterialTheme.colorScheme.surface
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp, top = 8.dp)
+        ) {
+            Text(
+                "Export Conversation",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+            )
+
+            HorizontalDivider(Modifier.padding(vertical = 8.dp))
+
+            ShareFormatRow(
+                title = "Plain Text",
+                subtitle = "Share as a readable .txt file",
+                icon = Icons.Default.TextFields,
+                onClick = { onFormatSelected("txt") }
+            )
+
+            ShareFormatRow(
+                title = "Markdown",
+                subtitle = "Share as a formatted .md file",
+                icon = Icons.Default.Description,
+                onClick = { onFormatSelected("md") }
+            )
+
+            ShareFormatRow(
+                title = "PDF",
+                subtitle = "Generate a PDF document (with math support)",
+                icon = Icons.Default.PictureAsPdf,
+                onClick = { onFormatSelected("pdf") }
+            )
+
+            ShareFormatRow(
+                title = "JSON",
+                subtitle = "Raw structured data format",
+                icon = Icons.Default.Code,
+                onClick = { onFormatSelected("json") }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ShareFormatRow(
+    title: String,
+    subtitle: String,
+    icon: ImageVector,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 24.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(24.dp)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Column {
+            Text(title, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)
+            Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the broken share conversation button and expands it with a BottomSheet that offers multiple export formats (Text, Markdown, PDF, JSON). Files are now properly saved to the cache and shared via a `FileProvider` URI to ensure compatibility with all email and social apps.

---
*PR created automatically by Jules for task [12623206923303114242](https://jules.google.com/task/12623206923303114242) started by @xnet-admin-1*