### PR TITLE
fix(chat): main broken after #90 — PDF export compile errors

### DIFF
--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/LatexPdfExporter.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/LatexPdfExporter.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
+import android.os.Bundle
+import android.os.CancellationSignal
 import android.os.Handler
 import android.os.Looper
 import android.os.ParcelFileDescriptor
@@ -48,6 +50,7 @@ object LatexPdfExporter {
   private fun doExport(activity: Activity, latexContent: String) {
     var webView: WebView? = null
     var host: FrameLayout? = null
+    val printed = AtomicBoolean(false)
     try {
       val html = buildHtml(latexContent)
       val web = WebView(activity)
@@ -72,7 +75,6 @@ object LatexPdfExporter {
       )
       web.layout(0, 0, w, h)
 
-      val printed = AtomicBoolean(false)
       val doPrint = Runnable {
         if (printed.compareAndSet(false, true)) {
           print(activity, web, hostLocal)
@@ -112,24 +114,27 @@ object LatexPdfExporter {
       val adapter = object : PrintDocumentAdapter() {
         override fun onStart() = delegate.onStart()
 
+        override fun onLayout(
+          oldAttributes: PrintAttributes?,
+          newAttributes: PrintAttributes?,
+          cancellationSignal: CancellationSignal?,
+          callback: PrintDocumentAdapter.LayoutResultCallback?,
+          extras: Bundle?,
+        ) = delegate.onLayout(oldAttributes, newAttributes, cancellationSignal, callback, extras)
+
         override fun onWrite(
-          attributes: PrintAttributes?,
-          pages: List<PageRange>?,
-          dest: ParcelFileDescriptor?,
+          pages: Array<PageRange>?,
+          destination: ParcelFileDescriptor?,
+          cancellationSignal: CancellationSignal?,
           callback: PrintDocumentAdapter.WriteResultCallback?,
-        ) = delegate.onWrite(attributes, pages, dest, callback)
+        ) = delegate.onWrite(pages, destination, cancellationSignal, callback)
 
         override fun onFinish() {
-          try { 
-            delegate.onFinish() 
+          try {
+            delegate.onFinish()
           } catch (t: Throwable) {
             Toast.makeText(activity, "Print may have failed: ${t.message}", Toast.LENGTH_SHORT).show()
           }
-          cleanup(webView, host)
-        }
-
-        override fun onCancel() {
-          try { delegate.onCancel() } catch (_: Throwable) {}
           cleanup(webView, host)
         }
       }


### PR DESCRIPTION
**Hotfix — main does not compile after #90.**

Verified with `:feature-chat:compileDebugKotlin`:

```
e: LatexPdfExporter.kt:103:7 Unresolved reference 'printed'
e: LatexPdfExporter.kt:112:21 Class '<anonymous>' is not abstract and does not implement abstract base class members
e: ... 'onWrite' overrides nothing
e: ... 'onCancel' overrides nothing
```

**Root causes (in the #90 merge):**

1. **`printed` out of scope** — `AtomicBoolean` was declared inside `try`, but `catch` calls `printed.set(true)` → unresolved reference. Moved before the `try`.
2. **`onWrite` signature wrong** — `List<PageRange>?` + missing `CancellationSignal` param. The modern framework (API 37) signature is `onWrite(PageRange[] pages, ParcelFileDescriptor dest, CancellationSignal cs, WriteResultCallback cb)` — confirmed via `javap` against `android-37.0/android.jar`. **PrintAttributes was removed** from this method in newer APIs.
3. **Missing `onLayout`** — abstract member never implemented → anonymous class fails instantiation.
4. **`onCancel` doesn't exist** on `PrintDocumentAdapter` (only `onStart`/`onLayout`/`onWrite`/`onFinish`) → removed; cleanup on cancel is already covered by `onFinish` (framework calls it after cancel/failure too).
5. Added missing imports (`Bundle`, `CancellationSignal`).

**Result:** `:feature-chat:compileDebugKotlin` → BUILD SUCCESSFUL.

The intent of your three edits is fully preserved — the `printed` guard in `catch` (prevents the 12s fallback from printing after cleanup), the toast on `onFinish` failure, and the delegate chaining.