### PR TITLE
style: make repo pass spotlessCheck (first CI run)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,6 +2,7 @@ name: Android CI
 
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   lint:

--- a/app/src/main/kotlin/ngo/xnet/aiope/AiopeApp.kt
+++ b/app/src/main/kotlin/ngo/xnet/aiope/AiopeApp.kt
@@ -7,7 +7,9 @@ import coil.decode.SvgDecoder
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class AiopeApp : Application(), ImageLoaderFactory {
+class AiopeApp :
+  Application(),
+  ImageLoaderFactory {
   override fun onCreate() {
     super.onCreate()
     ngo.xnet.aiope.feature.chat.engine.AgentSchedulerWorker.enqueue(this)

--- a/app/src/main/kotlin/ngo/xnet/aiope/MainActivity.kt
+++ b/app/src/main/kotlin/ngo/xnet/aiope/MainActivity.kt
@@ -12,11 +12,11 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
+import dagger.hilt.android.AndroidEntryPoint
 import ngo.xnet.aiope.core.navigation.AppComposeNavigator
 import ngo.xnet.aiope.feature.chat.settings.ProviderStore
 import ngo.xnet.aiope.feature.chat.settings.ToolStore
 import ngo.xnet.aiope.ui.AiopeMain
-import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/core-network/src/main/kotlin/ngo/xnet/aiope/core/network/LlmProvider.kt
+++ b/core-network/src/main/kotlin/ngo/xnet/aiope/core/network/LlmProvider.kt
@@ -94,7 +94,6 @@ data class ModelDef(
   val sampleRate: Int = 16000,
 )
 
-
 /** Provider profile — only connection info + selected model + per-model configs */
 data class ProviderProfile(
   val id: String = java.util.UUID.randomUUID().toString(),

--- a/core-preferences/src/main/kotlin/ngo/xnet/aiope/core/preferences/di/PreferencesModule.kt
+++ b/core-preferences/src/main/kotlin/ngo/xnet/aiope/core/preferences/di/PreferencesModule.kt
@@ -18,12 +18,12 @@ package ngo.xnet.aiope.core.preferences.di
 
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
-import ngo.xnet.aiope.core.preferences.Preferences
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import ngo.xnet.aiope.core.preferences.Preferences
 import javax.inject.Singleton
 
 @Module

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/AgentPanel.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/AgentPanel.kt
@@ -24,11 +24,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.fluid.compose.UniversalMarkdown
 import ngo.xnet.aiope.feature.chat.db.AgentEntity
 import ngo.xnet.aiope.feature.chat.db.AgentTaskEntity
 import ngo.xnet.aiope.feature.chat.db.ScheduledTaskEntity
 import ngo.xnet.aiope.feature.chat.engine.AgentExecutor
-import com.fluid.compose.UniversalMarkdown
 
 @Composable
 fun AgentPanel(
@@ -104,9 +104,15 @@ private fun SpawnTab(agents: List<AgentEntity>, onSpawn: (String, String) -> Uni
         Text(selectedAgent.ifEmpty { "Select Agent" }, fontSize = 12.sp)
       }
       DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-        DropdownMenuItem(text = { Text("default", fontSize = 12.sp) }, onClick = { selectedAgent = "default"; expanded = false })
+        DropdownMenuItem(text = { Text("default", fontSize = 12.sp) }, onClick = {
+          selectedAgent = "default"
+          expanded = false
+        })
         agents.forEach { agent ->
-          DropdownMenuItem(text = { Text(agent.name, fontSize = 12.sp) }, onClick = { selectedAgent = agent.name; expanded = false })
+          DropdownMenuItem(text = { Text(agent.name, fontSize = 12.sp) }, onClick = {
+            selectedAgent = agent.name
+            expanded = false
+          })
         }
       }
     }
@@ -193,8 +199,14 @@ private fun MonitorTab(
       task = selectedRunning!!,
       onDismiss = { selectedRunning = null },
       onSteer = onSteer,
-      onCancel = { onCancel(selectedRunning!!.id); selectedRunning = null },
-      onRerun = { onRerun(selectedRunning!!.id); selectedRunning = null },
+      onCancel = {
+        onCancel(selectedRunning!!.id)
+        selectedRunning = null
+      },
+      onRerun = {
+        onRerun(selectedRunning!!.id)
+        selectedRunning = null
+      },
     )
   }
 
@@ -203,7 +215,10 @@ private fun MonitorTab(
     PersistedTaskDialog(
       task = selectedPersisted!!,
       onDismiss = { selectedPersisted = null },
-      onRerun = { onRerun(selectedPersisted!!.id); selectedPersisted = null },
+      onRerun = {
+        onRerun(selectedPersisted!!.id)
+        selectedPersisted = null
+      },
       onSteer = onSteer,
     )
   }
@@ -428,11 +443,17 @@ private fun TimersTab(
   }
 
   if (showAdd) {
-    AddTimerDialog(agents = agents, onDismiss = { showAdd = false }, onSave = { onSave(it); showAdd = false })
+    AddTimerDialog(agents = agents, onDismiss = { showAdd = false }, onSave = {
+      onSave(it)
+      showAdd = false
+    })
   }
 
   if (editingTimer != null) {
-    AddTimerDialog(agents = agents, editing = editingTimer, onDismiss = { editingTimer = null }, onSave = { onSave(it); editingTimer = null })
+    AddTimerDialog(agents = agents, editing = editingTimer, onDismiss = { editingTimer = null }, onSave = {
+      onSave(it)
+      editingTimer = null
+    })
   }
 }
 
@@ -451,9 +472,13 @@ private fun TimerRow(timer: ScheduledTaskEntity, onEdit: () -> Unit, onDelete: (
       Text(timer.agentName, fontSize = 10.sp, color = Color(0xFFBBBBBB), fontWeight = FontWeight.Medium)
       Text(timer.prompt.take(50), fontSize = 9.sp, color = Color(0xFF777777), maxLines = 1)
       val schedule = buildString {
-        if (timer.oneShot) append("Once")
-        else if (timer.cronHour == -1) append("Every hour")
-        else append("${timer.cronHour}:${timer.cronMinute.toString().padStart(2, '0')}")
+        if (timer.oneShot) {
+          append("Once")
+        } else if (timer.cronHour == -1) {
+          append("Every hour")
+        } else {
+          append("${timer.cronHour}:${timer.cronMinute.toString().padStart(2, '0')}")
+        }
         if (timer.cronDaysOfWeek.isNotEmpty()) append(" (${timer.cronDaysOfWeek})")
       }
       Text(schedule, fontSize = 9.sp, color = Color(0xFF555555), fontFamily = FontFamily.Monospace)
@@ -468,7 +493,19 @@ private fun TimerRow(timer: ScheduledTaskEntity, onEdit: () -> Unit, onDelete: (
 private fun AddTimerDialog(agents: List<AgentEntity> = emptyList(), editing: ScheduledTaskEntity? = null, onDismiss: () -> Unit, onSave: (ScheduledTaskEntity) -> Unit) {
   var prompt by remember { mutableStateOf(editing?.prompt ?: "") }
   var selectedTools by remember { mutableStateOf(editing?.tools?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList<String>()) }
-  var preset by remember { mutableStateOf(if (editing?.oneShot == true) "once" else if (editing?.cronHour == -1) "hourly" else if (editing?.cronDaysOfWeek?.isNotEmpty() == true) "weekly" else "daily") }
+  var preset by remember {
+    mutableStateOf(
+      if (editing?.oneShot == true) {
+        "once"
+      } else if (editing?.cronHour == -1) {
+        "hourly"
+      } else if (editing?.cronDaysOfWeek?.isNotEmpty() == true) {
+        "weekly"
+      } else {
+        "daily"
+      },
+    )
+  }
   var hour by remember { mutableIntStateOf(editing?.cronHour?.takeIf { it >= 0 } ?: 9) }
   var minute by remember { mutableIntStateOf(editing?.cronMinute ?: 0) }
   var second by remember { mutableIntStateOf(0) }
@@ -560,7 +597,10 @@ private fun AddTimerDialog(agents: List<AgentEntity> = emptyList(), editing: Sch
               }
               DropdownMenu(expanded = monthExpanded, onDismissRequest = { monthExpanded = false }) {
                 monthNames.forEachIndexed { idx, name ->
-                  DropdownMenuItem(text = { Text(name, fontSize = 11.sp) }, onClick = { selectedMonth = idx - 1; monthExpanded = false })
+                  DropdownMenuItem(text = { Text(name, fontSize = 11.sp) }, onClick = {
+                    selectedMonth = idx - 1
+                    monthExpanded = false
+                  })
                 }
               }
             }
@@ -586,7 +626,7 @@ private fun AddTimerDialog(agents: List<AgentEntity> = emptyList(), editing: Sch
               cronDaysOfWeek = if (preset == "weekly") selectedDays else "",
               oneShot = preset == "once",
               nextRun = if (preset == "once") System.currentTimeMillis() + 60_000L else null,
-            )
+            ),
           )
         }
       }) { Text("Save") }
@@ -673,7 +713,10 @@ private fun BuilderTab(
     AgentEditorDialog(
       agent = editingAgent!!,
       models = models,
-      onSave = { onSave(it); editingAgent = null },
+      onSave = {
+        onSave(it)
+        editingAgent = null
+      },
       onDismiss = { editingAgent = null },
     )
   }
@@ -738,7 +781,8 @@ private fun AgentEditorDialog(
       ) {
         // Name
         OutlinedTextField(
-          value = name, onValueChange = { name = it },
+          value = name,
+          onValueChange = { name = it },
           label = { Text("Name", fontSize = 10.sp) },
           modifier = Modifier.fillMaxWidth().defaultMinSize(minHeight = 44.dp),
           textStyle = LocalTextStyle.current.copy(fontSize = 11.sp),
@@ -747,7 +791,8 @@ private fun AgentEditorDialog(
 
         // System Prompt
         OutlinedTextField(
-          value = prompt, onValueChange = { prompt = it },
+          value = prompt,
+          onValueChange = { prompt = it },
           label = { Text("System Prompt", fontSize = 10.sp) },
           modifier = Modifier.fillMaxWidth().defaultMinSize(minHeight = 80.dp),
           textStyle = LocalTextStyle.current.copy(fontSize = 10.sp),
@@ -761,9 +806,15 @@ private fun AgentEditorDialog(
             Text(model.ifEmpty { "(use active)" }, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
           }
           DropdownMenu(expanded = modelExpanded, onDismissRequest = { modelExpanded = false }) {
-            DropdownMenuItem(text = { Text("(use active)", fontSize = 11.sp) }, onClick = { model = ""; modelExpanded = false })
+            DropdownMenuItem(text = { Text("(use active)", fontSize = 11.sp) }, onClick = {
+              model = ""
+              modelExpanded = false
+            })
             models.forEach { m ->
-              DropdownMenuItem(text = { Text(m, fontSize = 11.sp) }, onClick = { model = m; modelExpanded = false })
+              DropdownMenuItem(text = { Text(m, fontSize = 11.sp) }, onClick = {
+                model = m
+                modelExpanded = false
+              })
             }
           }
         }
@@ -798,7 +849,8 @@ private fun AgentEditorDialog(
         Row(verticalAlignment = Alignment.CenterVertically) {
           Text("Top K: $topK", fontSize = 10.sp, color = Color(0xFF888888), modifier = Modifier.width(70.dp))
           Slider(
-            value = topK.toFloat(), onValueChange = { topK = it.toInt() },
+            value = topK.toFloat(),
+            onValueChange = { topK = it.toInt() },
             valueRange = 0f..100f,
             modifier = Modifier.weight(1f),
           )
@@ -808,7 +860,8 @@ private fun AgentEditorDialog(
         Row(verticalAlignment = Alignment.CenterVertically) {
           Text("Max Context: ${maxContext / 1000}k", fontSize = 10.sp, color = Color(0xFF888888), modifier = Modifier.width(100.dp))
           Slider(
-            value = maxContext.toFloat(), onValueChange = { maxContext = it.toInt() },
+            value = maxContext.toFloat(),
+            onValueChange = { maxContext = it.toInt() },
             valueRange = 4000f..128000f,
             steps = 30,
             modifier = Modifier.weight(1f),
@@ -832,7 +885,8 @@ private fun SliderRow(label: String, value: Float, range: ClosedFloatingPointRan
   Row(verticalAlignment = Alignment.CenterVertically) {
     Text("$label: ${format.format(value)}", fontSize = 10.sp, color = Color(0xFF888888), modifier = Modifier.width(100.dp))
     Slider(
-      value = value, onValueChange = onValueChange,
+      value = value,
+      onValueChange = onValueChange,
       valueRange = range,
       modifier = Modifier.weight(1f),
     )

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatScreen.kt
@@ -1,5 +1,7 @@
 package ngo.xnet.aiope.feature.chat
 
+import androidx.compose.animation.*
+import androidx.compose.animation.core.*
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -8,8 +10,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.animation.*
-import androidx.compose.animation.core.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
@@ -198,7 +198,7 @@ fun ChatScreen(viewModel: ChatViewModel = hiltViewModel(), onOpenSettings: () ->
       onFormatSelected = { format ->
         showShareSheet = false
         viewModel.shareConversation(format, context)
-      }
+      },
     )
   }
 }
@@ -399,15 +399,25 @@ private fun ChatContent(
             when (event) {
               "switch-mode" -> {
                 val mode = data["mode"]?.uppercase()?.let { m ->
-                  try { ngo.xnet.aiope.feature.chat.engine.AgentMode.valueOf(m) } catch (_: Exception) { null }
+                  try {
+                    ngo.xnet.aiope.feature.chat.engine.AgentMode.valueOf(m)
+                  } catch (_: Exception) {
+                    null
+                  }
                 }
                 if (mode != null) onModeChange(mode)
               }
+
               "switch-model" -> data["model"]?.let { onSwitchModel(it) }
+
               "auto-run" -> onAutoRunChange(data["enabled"]?.toBooleanStrictOrNull() ?: true)
+
               "open-settings" -> onOpenSettings()
+
               "toggle-terminal" -> onToggleTerminal()
+
               "toggle-browser" -> onToggleBrowser()
+
               else -> {
                 val msg = if (data.isNotEmpty()) "Responded with: ${data.entries.joinToString(", ") { "${it.key}: ${it.value}" }}" else "Pressed: $event"
                 onSend(msg, emptyList())
@@ -554,30 +564,32 @@ private fun ChatInput(onSend: (String, List<String>) -> Unit, onStop: () -> Unit
       val mime = context.contentResolver.getType(it) ?: ""
       if (mime.startsWith("image/")) {
         pendingImages.add(it.toString())
-      } else scope.launch(kotlinx.coroutines.Dispatchers.IO) {
-        val result = if (mime == "application/pdf") {
-        try {
-          val bytes = context.contentResolver.openInputStream(it)?.use { s -> s.readBytes() } ?: byteArrayOf()
-          val name = it.lastPathSegment ?: "document.pdf"
-          com.tom_roush.pdfbox.android.PDFBoxResourceLoader.init(context)
-          val doc = com.tom_roush.pdfbox.pdmodel.PDDocument.load(bytes)
-          val pageCount = doc.numberOfPages
-          val extracted = com.tom_roush.pdfbox.text.PDFTextStripper().getText(doc).take(100000)
-          doc.close()
-          (if (text.isNotBlank()) "\n" else "") + "[$name - $pageCount pages]\n${extracted.ifBlank { "[No extractable text]" }}"
-        } catch (e: Exception) {
-          "\n[PDF error: ${e.message}]"
-        }
       } else {
-        try {
-          val content = context.contentResolver.openInputStream(it)?.bufferedReader()?.readText()?.take(10000) ?: ""
-          val name = it.lastPathSegment ?: "file"
-          (if (text.isNotBlank()) "\n" else "") + "[$name]\n$content"
-        } catch (_: Exception) {
-          "\n[Attached: $it]"
+        scope.launch(kotlinx.coroutines.Dispatchers.IO) {
+          val result = if (mime == "application/pdf") {
+            try {
+              val bytes = context.contentResolver.openInputStream(it)?.use { s -> s.readBytes() } ?: byteArrayOf()
+              val name = it.lastPathSegment ?: "document.pdf"
+              com.tom_roush.pdfbox.android.PDFBoxResourceLoader.init(context)
+              val doc = com.tom_roush.pdfbox.pdmodel.PDDocument.load(bytes)
+              val pageCount = doc.numberOfPages
+              val extracted = com.tom_roush.pdfbox.text.PDFTextStripper().getText(doc).take(100000)
+              doc.close()
+              (if (text.isNotBlank()) "\n" else "") + "[$name - $pageCount pages]\n${extracted.ifBlank { "[No extractable text]" }}"
+            } catch (e: Exception) {
+              "\n[PDF error: ${e.message}]"
+            }
+          } else {
+            try {
+              val content = context.contentResolver.openInputStream(it)?.bufferedReader()?.readText()?.take(10000) ?: ""
+              val name = it.lastPathSegment ?: "file"
+              (if (text.isNotBlank()) "\n" else "") + "[$name]\n$content"
+            } catch (_: Exception) {
+              "\n[Attached: $it]"
+            }
+          }
+          kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) { text = text + result }
         }
-      }
-        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) { text = text + result }
       }
     }
   }
@@ -659,13 +671,16 @@ private fun ChatInput(onSend: (String, List<String>) -> Unit, onStop: () -> Unit
       }
       // Realtime voice button (always available via task model)
       IconButton(
-        onClick = { onToggleVoice() }
+        onClick = { onToggleVoice() },
       ) {
         Icon(
           imageVector = if (isInRealtimeVoice) Icons.Default.CallEnd else Icons.Default.Call,
           contentDescription = if (isInRealtimeVoice) "End voice call" else "Start voice call",
-          tint = if (isInRealtimeVoice) MaterialTheme.colorScheme.error 
-                 else MaterialTheme.colorScheme.primary
+          tint = if (isInRealtimeVoice) {
+            MaterialTheme.colorScheme.error
+          } else {
+            MaterialTheme.colorScheme.primary
+          },
         )
       }
       // Waveform visualization when in voice mode
@@ -673,7 +688,7 @@ private fun ChatInput(onSend: (String, List<String>) -> Unit, onStop: () -> Unit
         RealtimeWaveform(
           isListening = isVoiceListening,
           isSpeaking = isVoiceSpeaking,
-          modifier = Modifier.weight(1f)
+          modifier = Modifier.weight(1f),
         )
       }
       // Clear
@@ -768,51 +783,57 @@ private fun ConversationSheet(viewModel: ChatViewModel, onDismiss: () -> Unit) {
 fun RealtimeWaveform(
   isListening: Boolean,
   isSpeaking: Boolean,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   val infiniteTransition = rememberInfiniteTransition(label = "waveform")
-  
+
   val alpha1 by infiniteTransition.animateFloat(
-    initialValue = 0.3f, targetValue = 1f,
+    initialValue = 0.3f,
+    targetValue = 1f,
     animationSpec = infiniteRepeatable(
       animation = tween(300, easing = LinearEasing),
-      repeatMode = RepeatMode.Reverse
-    ), label = "a1"
+      repeatMode = RepeatMode.Reverse,
+    ),
+    label = "a1",
   )
   val alpha2 by infiniteTransition.animateFloat(
-    initialValue = 1f, targetValue = 0.3f,
+    initialValue = 1f,
+    targetValue = 0.3f,
     animationSpec = infiniteRepeatable(
       animation = tween(400, easing = LinearEasing),
-      repeatMode = RepeatMode.Reverse
-    ), label = "a2"
+      repeatMode = RepeatMode.Reverse,
+    ),
+    label = "a2",
   )
   val alpha3 by infiniteTransition.animateFloat(
-    initialValue = 0.5f, targetValue = 1f,
+    initialValue = 0.5f,
+    targetValue = 1f,
     animationSpec = infiniteRepeatable(
       animation = tween(350, easing = LinearEasing),
-      repeatMode = RepeatMode.Reverse
-    ), label = "a3"
+      repeatMode = RepeatMode.Reverse,
+    ),
+    label = "a3",
   )
-  
+
   val color = when {
     isSpeaking -> MaterialTheme.colorScheme.primary
     isListening -> MaterialTheme.colorScheme.tertiary
     else -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
   }
-  
+
   Row(
     modifier = modifier
       .fillMaxWidth()
       .padding(horizontal = 8.dp),
     horizontalArrangement = Arrangement.Center,
-    verticalAlignment = Alignment.CenterVertically
+    verticalAlignment = Alignment.CenterVertically,
   ) {
     val barHeights = if (isListening || isSpeaking) {
       listOf(alpha1, alpha2, alpha3, alpha2, alpha1)
     } else {
       listOf(0.3f, 0.3f, 0.3f, 0.3f, 0.3f)
     }
-    
+
     barHeights.forEach { alpha ->
       Box(
         modifier = Modifier
@@ -820,8 +841,8 @@ fun RealtimeWaveform(
           .height((20 * alpha).dp)
           .background(
             color = color.copy(alpha = alpha),
-            shape = RoundedCornerShape(2.dp)
-          )
+            shape = RoundedCornerShape(2.dp),
+          ),
       )
       Spacer(modifier = Modifier.width(2.dp))
     }

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatViewModel.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatViewModel.kt
@@ -3,6 +3,12 @@ package ngo.xnet.aiope.feature.chat
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import ngo.xnet.aiope.core.model.RemoteToolBridge
 import ngo.xnet.aiope.core.network.ModelConfig
 import ngo.xnet.aiope.core.network.ModelDef
@@ -11,23 +17,17 @@ import ngo.xnet.aiope.core.network.ProviderTemplates
 import ngo.xnet.aiope.feature.chat.db.ChatDao
 import ngo.xnet.aiope.feature.chat.db.ConversationEntity
 import ngo.xnet.aiope.feature.chat.db.MessageEntity
-import ngo.xnet.aiope.feature.chat.engine.StreamingOrchestrator
+import ngo.xnet.aiope.feature.chat.engine.AudioConfig
 import ngo.xnet.aiope.feature.chat.engine.RealtimeAudioManager
 import ngo.xnet.aiope.feature.chat.engine.RealtimeStreaming
 import ngo.xnet.aiope.feature.chat.engine.SafeOkHttp
-import ngo.xnet.aiope.feature.chat.engine.AudioConfig
 import ngo.xnet.aiope.feature.chat.engine.StreamEvent
+import ngo.xnet.aiope.feature.chat.engine.StreamingOrchestrator
 import ngo.xnet.aiope.feature.chat.engine.TokenCounter
 import ngo.xnet.aiope.feature.chat.engine.ToolExecutor
 import ngo.xnet.aiope.feature.chat.settings.McpManager
 import ngo.xnet.aiope.feature.chat.settings.ProviderStore
 import ngo.xnet.aiope.feature.chat.settings.ToolStore
-import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.util.UUID
 import javax.inject.Inject
 
@@ -43,9 +43,7 @@ class ChatViewModel @Inject constructor(
 
   private val connectivityManager = application.getSystemService(android.net.ConnectivityManager::class.java)
 
-  private fun isOnline(): Boolean =
-    connectivityManager?.activeNetwork?.let { connectivityManager.getNetworkCapabilities(it)?.hasCapability(android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET) } ?: false
-
+  private fun isOnline(): Boolean = connectivityManager?.activeNetwork?.let { connectivityManager.getNetworkCapabilities(it)?.hasCapability(android.net.NetworkCapabilities.NET_CAPABILITY_INTERNET) } ?: false
 
   private val _messages = MutableStateFlow<List<ChatMessage>>(emptyList())
   val messages = _messages.asStateFlow()
@@ -119,9 +117,11 @@ class ChatViewModel @Inject constructor(
 
     realtimeStreamingJob = viewModelScope.launch(Dispatchers.IO) {
       try {
-        val sysPrompt = (buildSystemMessages(ModelConfig(modelId = resolvedModelId))
-            .firstOrNull { it.first == "system" }?.second ?: "") +
-            "\n\nYou are in a live voice session with full tool access. Execute all tools directly and autonomously — never tell the user to do something manually. You can browse, click, fill forms, run commands, send messages, and perform any action yourself."
+        val sysPrompt = (
+          buildSystemMessages(ModelConfig(modelId = resolvedModelId))
+            .firstOrNull { it.first == "system" }?.second ?: ""
+          ) +
+          "\n\nYou are in a live voice session with full tool access. Execute all tools directly and autonomously — never tell the user to do something manually. You can browse, click, fill forms, run commands, send messages, and perform any action yourself."
         val realtimeStream = RealtimeStreaming(
           okHttp = okHttp,
           modelDef = modelDef,
@@ -129,7 +129,7 @@ class ChatViewModel @Inject constructor(
           provider = profile,
           audioManager = realtimeAudioManager!!,
           systemPrompt = sysPrompt,
-          voiceName = ngo.xnet.aiope.feature.chat.settings.getVoiceName(getApplication())
+          voiceName = ngo.xnet.aiope.feature.chat.settings.getVoiceName(getApplication()),
         )
         this@ChatViewModel.realtimeStream = realtimeStream
 
@@ -140,10 +140,12 @@ class ChatViewModel @Inject constructor(
               // Text parts from model (rare with audio-only, but handle)
               currentTurnText.append(event.text)
             }
+
             is StreamEvent.AudioChunk -> {
               realtimeAudioManager?.playAudio(event.pcmData)
               viewModelScope.launch(Dispatchers.Main) { _isVoiceSpeaking.value = true }
             }
+
             is StreamEvent.TurnComplete -> {
               // Persist the assistant message
               if (voiceTurnId.isNotBlank()) {
@@ -162,7 +164,9 @@ class ChatViewModel @Inject constructor(
                 _isVoiceListening.value = true
               }
             }
+
             is StreamEvent.Connected -> {}
+
             is StreamEvent.InputTranscription -> {
               val msgId = java.util.UUID.randomUUID().toString()
               viewModelScope.launch(Dispatchers.Main) {
@@ -173,6 +177,7 @@ class ChatViewModel @Inject constructor(
                 chatDao.insertMessage(MessageEntity(id = msgId, conversationId = conversationId, role = Role.USER.value, content = event.text))
               }
             }
+
             is StreamEvent.OutputTranscription -> {
               viewModelScope.launch(Dispatchers.Main) {
                 val msgs = _messages.value.toMutableList()
@@ -186,6 +191,7 @@ class ChatViewModel @Inject constructor(
                 _messages.value = msgs
               }
             }
+
             is StreamEvent.Error -> {
               if (!event.message.isNullOrBlank()) {
                 viewModelScope.launch(Dispatchers.Main) {
@@ -194,15 +200,19 @@ class ChatViewModel @Inject constructor(
               }
               stopRealtimeVoice()
             }
+
             is StreamEvent.ToolCallEvent -> {
               val responses = event.functionCalls.map { fc ->
                 val result = try {
                   toolExecutor.execute(fc.name, fc.args)
-                } catch (e: Exception) { "Error: ${e.message}" }
+                } catch (e: Exception) {
+                  "Error: ${e.message}"
+                }
                 fc.id to result
               }
               realtimeStream.sendToolResponse(responses)
             }
+
             else -> {}
           }
         }
@@ -228,7 +238,9 @@ class ChatViewModel @Inject constructor(
     realtimeStreamingJob?.cancel()
     realtimeStreamingJob = null
     realtimeStream = null
-    try { realtimeAudioManager?.stop() } catch (_: Exception) {}
+    try {
+      realtimeAudioManager?.stop()
+    } catch (_: Exception) {}
     realtimeAudioManager = null
     try {
       val am = getApplication<android.app.Application>().getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager
@@ -251,7 +263,6 @@ class ChatViewModel @Inject constructor(
     return ModelDef(id = modelId, supportsAudio = audio, useStreaming = audio)
   }
 
-
   private val _terminalVisible = MutableStateFlow(false)
   val terminalVisible = _terminalVisible.asStateFlow()
   private val _browserVisible = MutableStateFlow(false)
@@ -269,7 +280,9 @@ class ChatViewModel @Inject constructor(
 
   private var conversationId: String
     get() = savedState["conversationId"] ?: UUID.randomUUID().toString().also { savedState["conversationId"] = it }
-    set(value) { savedState["conversationId"] = value }
+    set(value) {
+      savedState["conversationId"] = value
+    }
 
   val _modelLabel = MutableStateFlow("")
   val modelLabel: String get() = _modelLabel.value
@@ -381,11 +394,12 @@ class ChatViewModel @Inject constructor(
         msgs.forEach { m ->
           arr.put(
             org.json.JSONObject().put("role", m.role.value).put("content", m.content)
-              .apply { if (m.toolCalls.isNotEmpty()) put("tool_calls", org.json.JSONArray(m.toolCalls)) }
+              .apply { if (m.toolCalls.isNotEmpty()) put("tool_calls", org.json.JSONArray(m.toolCalls)) },
           )
         }
         org.json.JSONObject().put("title", conversationId).put("exported", System.currentTimeMillis()).put("messages", arr).toString(2)
       }
+
       "txt" -> {
         buildString {
           msgs.forEach { m ->
@@ -398,6 +412,7 @@ class ChatViewModel @Inject constructor(
           }
         }
       }
+
       else -> { // markdown and pdf use the same base content
         buildString {
           append("# AIOPE Conversation\n\n")
@@ -445,9 +460,9 @@ class ChatViewModel @Inject constructor(
 
         val uri = androidx.core.content.FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
         val mimeType = when (format) {
-           "json" -> "application/json"
-           "md" -> "text/markdown"
-           else -> "text/plain"
+          "json" -> "application/json"
+          "md" -> "text/markdown"
+          else -> "text/plain"
         }
 
         val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
@@ -496,7 +511,9 @@ class ChatViewModel @Inject constructor(
         // Try local model first
         val localResult = try {
           null
-        } catch (_: Exception) { null }
+        } catch (_: Exception) {
+          null
+        }
 
         if (localResult != null) {
           val updated = _messages.value.toMutableList()
@@ -546,7 +563,9 @@ class ChatViewModel @Inject constructor(
         // Try local model first
         val localTitle = try {
           null
-        } catch (_: Exception) { null }
+        } catch (_: Exception) {
+          null
+        }
 
         if (localTitle != null) {
           chatDao.updateConversation(conversationId, localTitle)
@@ -571,7 +590,9 @@ class ChatViewModel @Inject constructor(
           chatDao.updateConversation(conversationId, title)
           refreshConversations()
         }
-      } catch (e: Exception) { android.util.Log.w("ChatVM", "title gen failed: ${e.message}") }
+      } catch (e: Exception) {
+        android.util.Log.w("ChatVM", "title gen failed: ${e.message}")
+      }
     }
   }
 
@@ -600,7 +621,8 @@ class ChatViewModel @Inject constructor(
       val savedPaths = ngo.xnet.aiope.feature.chat.engine.ImageProcessor.saveImagesToDisk(
         getApplication<android.app.Application>().filesDir,
         getApplication<android.app.Application>().contentResolver,
-        userMsg.id, imageUris,
+        userMsg.id,
+        imageUris,
       )
       chatDao.insertMessage(
         MessageEntity(
@@ -900,7 +922,7 @@ Rules:
 
 TRANSCRIPT:
 $transcript
-""".trimIndent()
+        """.trimIndent()
         val orchestrator = StreamingOrchestrator(
           baseUrl = profile.effectiveApiBase(),
           apiKey = profile.apiKey,
@@ -966,7 +988,6 @@ $transcript
     }
   }
 
-  /** Send to LLM without adding a new user message (used by retry) */
   /** Shared streaming collection logic used by send() and resend(). Returns final content string. */
   private suspend fun collectStream(
     orchestrator: StreamingOrchestrator,
@@ -985,7 +1006,10 @@ $transcript
 
     orchestrator.stream(messages, imageBase64s).collect { chunk ->
       chunk.reasoning?.let { r ->
-        if (!isReasoning) { isReasoning = true; currentReasoning.clear() }
+        if (!isReasoning) {
+          isReasoning = true
+          currentReasoning.clear()
+        }
         currentReasoning.append(r)
       }
       // Handle content replacement (strips tool markup from display)
@@ -995,13 +1019,17 @@ $transcript
       }
       if (chunk.content.isNotEmpty()) {
         if (isReasoning && currentReasoning.isNotEmpty()) {
-          reasoningBlocks.add(currentReasoning.toString()); currentReasoning.clear(); isReasoning = false
+          reasoningBlocks.add(currentReasoning.toString())
+          currentReasoning.clear()
+          isReasoning = false
         }
         sb.append(chunk.content)
       }
       chunk.toolCalls?.let { calls ->
         if (isReasoning && currentReasoning.isNotEmpty()) {
-          reasoningBlocks.add(currentReasoning.toString()); currentReasoning.clear(); isReasoning = false
+          reasoningBlocks.add(currentReasoning.toString())
+          currentReasoning.clear()
+          isReasoning = false
         }
         for (c in calls) toolCallsList.add("${c.name}(${c.arguments.entries.joinToString(", ") { "${it.key}=${it.value}" }})")
       }
@@ -1013,7 +1041,8 @@ $transcript
       }
       chunk.error?.let { sb.append("\nError: $it") }
       if (chunk.isDone && isReasoning && currentReasoning.isNotEmpty()) {
-        reasoningBlocks.add(currentReasoning.toString()); isReasoning = false
+        reasoningBlocks.add(currentReasoning.toString())
+        isReasoning = false
       }
       val allReasoning = if (isReasoning && currentReasoning.isNotEmpty()) reasoningBlocks + currentReasoning.toString() else reasoningBlocks.toList()
       val currentLen = sb.length
@@ -1024,8 +1053,12 @@ $transcript
         withContext(Dispatchers.Main) {
           _messages.value = _messages.value.toMutableList().also {
             it[it.lastIndex] = it.last().copy(
-              content = sb.toString(), reasoning = allReasoning, isReasoningDone = !isReasoning,
-              toolCalls = toolCallsList.toList(), toolResults = toolResultsList.toList(), toolErrors = toolErrorsList.toList(),
+              content = sb.toString(),
+              reasoning = allReasoning,
+              isReasoningDone = !isReasoning,
+              toolCalls = toolCallsList.toList(),
+              toolResults = toolResultsList.toList(),
+              toolErrors = toolErrorsList.toList(),
               locationData = if (toolExecutor.locationUsedThisTurn) toolExecutor.lastLocationData else null,
             )
           }
@@ -1053,6 +1086,7 @@ $transcript
         _messages.value.dropLast(1).forEach { msg ->
           when (msg.role) {
             Role.USER -> chatMessages.add("user" to msg.content)
+
             Role.ASSISTANT -> {
               var content = msg.content
               if (msg.toolCalls.isNotEmpty()) {
@@ -1065,6 +1099,7 @@ $transcript
               }
               chatMessages.add("assistant" to content)
             }
+
             else -> {}
           }
         }
@@ -1147,7 +1182,11 @@ $transcript
         },
         buildMessages = { agent, prompt ->
           val agentPrompt = agent?.prompt ?: "You are a helpful agent. Complete the given task using your tools."
-          val remoteCtx = try { kotlinx.coroutines.runBlocking { remoteToolBridge.buildSystemContext() } } catch (_: Exception) { "" }
+          val remoteCtx = try {
+            kotlinx.coroutines.runBlocking { remoteToolBridge.buildSystemContext() }
+          } catch (_: Exception) {
+            ""
+          }
           val envContext = """
 
 ## Environment

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/LatexPdfExporter.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/LatexPdfExporter.kt
@@ -68,7 +68,7 @@ object LatexPdfExporter {
       hostLocal.addView(web, FrameLayout.LayoutParams(w, h))
       hostLocal.translationY = 100000f
       (activity.window?.decorView as? ViewGroup)?.addView(hostLocal, FrameLayout.LayoutParams(w, h))
-      
+
       web.measure(
         View.MeasureSpec.makeMeasureSpec(w, View.MeasureSpec.EXACTLY),
         View.MeasureSpec.makeMeasureSpec(h, View.MeasureSpec.EXACTLY),
@@ -151,8 +151,12 @@ object LatexPdfExporter {
   }
 
   private fun cleanup(webView: WebView?, host: FrameLayout?) {
-    try { (host?.parent as? ViewGroup)?.removeView(host) } catch (_: Throwable) {}
-    try { webView?.destroy() } catch (_: Throwable) {}
+    try {
+      (host?.parent as? ViewGroup)?.removeView(host)
+    } catch (_: Throwable) {}
+    try {
+      webView?.destroy()
+    } catch (_: Throwable) {}
   }
 
   /** Unwrap ContextWrapper chains (e.g. ContextThemeWrapper) to find the Activity. */

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/MessageBubble.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/MessageBubble.kt
@@ -22,8 +22,8 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.ForkRight
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material.icons.filled.VolumeOff
 import androidx.compose.material.icons.filled.VolumeUp

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ShareFormatSheet.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ShareFormatSheet.kt
@@ -18,82 +18,82 @@ import androidx.compose.ui.unit.sp
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ShareFormatSheet(
-    onDismissRequest: () -> Unit,
-    onFormatSelected: (String) -> Unit
+  onDismissRequest: () -> Unit,
+  onFormatSelected: (String) -> Unit,
 ) {
-    ModalBottomSheet(
-        onDismissRequest = onDismissRequest,
-        dragHandle = { BottomSheetDefaults.DragHandle() },
-        containerColor = MaterialTheme.colorScheme.surface
+  ModalBottomSheet(
+    onDismissRequest = onDismissRequest,
+    dragHandle = { BottomSheetDefaults.DragHandle() },
+    containerColor = MaterialTheme.colorScheme.surface,
+  ) {
+    Column(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(bottom = 32.dp, top = 8.dp),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 32.dp, top = 8.dp)
-        ) {
-            Text(
-                "Export Conversation",
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-            )
+      Text(
+        "Export Conversation",
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+      )
 
-            HorizontalDivider(Modifier.padding(vertical = 8.dp))
+      HorizontalDivider(Modifier.padding(vertical = 8.dp))
 
-            ShareFormatRow(
-                title = "Plain Text",
-                subtitle = "Share as a readable .txt file",
-                icon = Icons.Default.TextFields,
-                onClick = { onFormatSelected("txt") }
-            )
+      ShareFormatRow(
+        title = "Plain Text",
+        subtitle = "Share as a readable .txt file",
+        icon = Icons.Default.TextFields,
+        onClick = { onFormatSelected("txt") },
+      )
 
-            ShareFormatRow(
-                title = "Markdown",
-                subtitle = "Share as a formatted .md file",
-                icon = Icons.Default.Description,
-                onClick = { onFormatSelected("md") }
-            )
+      ShareFormatRow(
+        title = "Markdown",
+        subtitle = "Share as a formatted .md file",
+        icon = Icons.Default.Description,
+        onClick = { onFormatSelected("md") },
+      )
 
-            ShareFormatRow(
-                title = "PDF",
-                subtitle = "Generate a PDF document (with math support)",
-                icon = Icons.Default.PictureAsPdf,
-                onClick = { onFormatSelected("pdf") }
-            )
+      ShareFormatRow(
+        title = "PDF",
+        subtitle = "Generate a PDF document (with math support)",
+        icon = Icons.Default.PictureAsPdf,
+        onClick = { onFormatSelected("pdf") },
+      )
 
-            ShareFormatRow(
-                title = "JSON",
-                subtitle = "Raw structured data format",
-                icon = Icons.Default.Code,
-                onClick = { onFormatSelected("json") }
-            )
-        }
+      ShareFormatRow(
+        title = "JSON",
+        subtitle = "Raw structured data format",
+        icon = Icons.Default.Code,
+        onClick = { onFormatSelected("json") },
+      )
     }
+  }
 }
 
 @Composable
 private fun ShareFormatRow(
-    title: String,
-    subtitle: String,
-    icon: ImageVector,
-    onClick: () -> Unit
+  title: String,
+  subtitle: String,
+  icon: ImageVector,
+  onClick: () -> Unit,
 ) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 24.dp, vertical = 16.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(24.dp)
-        )
-        Spacer(modifier = Modifier.width(16.dp))
-        Column {
-            Text(title, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)
-            Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .clickable(onClick = onClick)
+      .padding(horizontal = 24.dp, vertical = 16.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Icon(
+      imageVector = icon,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.primary,
+      modifier = Modifier.size(24.dp),
+    )
+    Spacer(modifier = Modifier.width(16.dp))
+    Column {
+      Text(title, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)
+      Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
+  }
 }

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/browser/BrowserServer.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/browser/BrowserServer.kt
@@ -44,7 +44,9 @@ object BrowserServer {
           val socket = ss.accept()
           if (!connectionSemaphore.tryAcquire()) {
             // At capacity — reject
-            try { socket.close() } catch (_: Exception) {}
+            try {
+              socket.close()
+            } catch (_: Exception) {}
             continue
           }
           launch {

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/browser/WebBrowser.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/browser/WebBrowser.kt
@@ -91,7 +91,7 @@ class WebBrowser(context: Context) {
 
     var trimmed = text.substring(safeOffset, end)
     if (end < text.length) {
-       trimmed += "\n...(truncated. Use offset=${end} to read more)"
+      trimmed += "\n...(truncated. Use offset=$end to read more)"
     }
 
     return "URL: $url\nTitle: $title\nContent Length: ${text.length}\nShowing: $safeOffset to $end\n\n$trimmed"

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/di/ChatModule.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/di/ChatModule.kt
@@ -4,18 +4,18 @@ import android.content.Context
 import androidx.room.Room
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import ngo.xnet.aiope.feature.chat.db.AgentSeeder
-import ngo.xnet.aiope.feature.chat.db.ChatDao
-import ngo.xnet.aiope.feature.chat.db.ChatDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import ngo.xnet.aiope.feature.chat.db.AgentSeeder
+import ngo.xnet.aiope.feature.chat.db.ChatDao
+import ngo.xnet.aiope.feature.chat.db.ChatDatabase
+import javax.inject.Singleton
 
 val MIGRATION_1_2 = object : Migration(1, 2) {
   override fun migrate(db: SupportSQLiteDatabase) {

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/dynamicui/AiopeUiRenderer.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/dynamicui/AiopeUiRenderer.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -28,7 +29,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.UriHandler
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -69,10 +69,14 @@ fun AiopeUiRenderer(
               val kv = p.split("=", limit = 2)
               kv[0] to (kv.getOrNull(1)?.let { java.net.URLDecoder.decode(it, "UTF-8") } ?: "")
             }
-          } else emptyMap()
+          } else {
+            emptyMap()
+          }
           onCallback(action, params)
         } else {
-          try { systemUriHandler.openUri(uri) } catch (_: Exception) {}
+          try {
+            systemUriHandler.openUri(uri)
+          } catch (_: Exception) {}
         }
       }
     }

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/AgentExecutor.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/AgentExecutor.kt
@@ -1,11 +1,11 @@
 package ngo.xnet.aiope.feature.chat.engine
 
-import ngo.xnet.aiope.feature.chat.db.AgentEntity
-import ngo.xnet.aiope.feature.chat.db.AgentTaskEntity
-import ngo.xnet.aiope.feature.chat.db.ChatDao
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import ngo.xnet.aiope.feature.chat.db.AgentEntity
+import ngo.xnet.aiope.feature.chat.db.AgentTaskEntity
+import ngo.xnet.aiope.feature.chat.db.ChatDao
 import java.util.UUID
 
 /**
@@ -51,8 +51,14 @@ class AgentExecutor(
   )
 
   private val readOnlyTools = setOf(
-    "search_web", "search_images", "search_location", "fetch_url",
-    "read_file", "list_directory", "query_data", "memory_recall",
+    "search_web",
+    "search_images",
+    "search_location",
+    "fetch_url",
+    "read_file",
+    "list_directory",
+    "query_data",
+    "memory_recall",
   )
 
   /**
@@ -83,7 +89,7 @@ class AgentExecutor(
         prompt = prompt,
         status = "running",
         conversationId = conversationId,
-      )
+      ),
     )
 
     return try {
@@ -125,8 +131,9 @@ class AgentExecutor(
 
       val result = sb.toString().ifEmpty {
         val log = toolLog.toString()
-        if (log.isBlank()) "(agent completed with no output)"
-        else {
+        if (log.isBlank()) {
+          "(agent completed with no output)"
+        } else {
           // Extract markdown images from tool results so they render properly
           val images = Regex("""!\[[^\]]*]\([^)]+\)""").findAll(log).map { it.value }.distinct().take(20).toList()
           val textContent = log.replace(Regex("""\[(search_web|search_images|fetch_url|read_file|list_directory|query_data|ssh_exec|ssh_start)]:"""), "•")
@@ -147,9 +154,7 @@ class AgentExecutor(
   }
 
   /** Legacy compat — run with no agent name (uses read-only tools) */
-  suspend fun runBlocking(description: String, prompt: String): String {
-    return runAgent("default", prompt)
-  }
+  suspend fun runBlocking(description: String, prompt: String): String = runAgent("default", prompt)
 
   fun clear() {
     _tasks.value = emptyList()

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/AgentSchedulerWorker.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/AgentSchedulerWorker.kt
@@ -6,12 +6,12 @@ import android.content.Context
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.work.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import ngo.xnet.aiope.core.network.ProviderProfile
 import ngo.xnet.aiope.feature.chat.db.AgentEntity
 import ngo.xnet.aiope.feature.chat.db.ChatDatabase
 import ngo.xnet.aiope.feature.chat.db.ScheduledTaskEntity
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
@@ -27,7 +27,9 @@ class AgentSchedulerWorker(
 
   override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
     val db = androidx.room.Room.databaseBuilder(
-      appContext, ChatDatabase::class.java, "aiope-chat.db"
+      appContext,
+      ChatDatabase::class.java,
+      "aiope-chat.db",
     ).addMigrations(
       ngo.xnet.aiope.feature.chat.di.MIGRATION_1_2,
       ngo.xnet.aiope.feature.chat.di.MIGRATION_2_3,
@@ -60,7 +62,7 @@ class AgentSchedulerWorker(
             prompt = task.prompt,
             status = "running",
             scheduledTaskId = task.id,
-          )
+          ),
         )
 
         // Update schedule timing
@@ -102,42 +104,40 @@ class AgentSchedulerWorker(
     dao: ngo.xnet.aiope.feature.chat.db.ChatDao,
     provider: ProviderProfile,
     task: ScheduledTaskEntity,
-  ): String {
-    return try {
-      // Resolve agent config
-      val agent: AgentEntity? = dao.getAgentByName(task.agentName)
-      val basePrompt = agent?.prompt ?: "You are a scheduled task agent. Complete the assigned task using your tools."
-      val systemPrompt = basePrompt + "\n\n## Environment\n- Date/Time: " + java.time.ZonedDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("EEEE, yyyy-MM-dd HH:mm:ss z")) + "\n- Platform: Android (AIOPE scheduled task)\n- Execution: Background (WorkManager)\n\n## Tool Execution\nYou MUST use tools to complete your task.\n- search_web: search the web\n- fetch_url: fetch URL content\n- read_file/write_file/list_directory: filesystem\n- run_sh: shell commands\n- send_sms: send SMS\n- send_notification: show notification\n- set_alarm: set alarm\n- ssh_exec: remote command\n- memory_store/memory_recall: persistent memory\n\nDO NOT describe what you would do — actually DO it with tools.\nIf a tool fails, try an alternative. When finished, summarize what was accomplished."
-      val modelId = agent?.model?.ifEmpty { null } ?: provider.selectedModelId
-      val temperature = agent?.temperature ?: 0.7f
+  ): String = try {
+    // Resolve agent config
+    val agent: AgentEntity? = dao.getAgentByName(task.agentName)
+    val basePrompt = agent?.prompt ?: "You are a scheduled task agent. Complete the assigned task using your tools."
+    val systemPrompt = basePrompt + "\n\n## Environment\n- Date/Time: " + java.time.ZonedDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("EEEE, yyyy-MM-dd HH:mm:ss z")) + "\n- Platform: Android (AIOPE scheduled task)\n- Execution: Background (WorkManager)\n\n## Tool Execution\nYou MUST use tools to complete your task.\n- search_web: search the web\n- fetch_url: fetch URL content\n- read_file/write_file/list_directory: filesystem\n- run_sh: shell commands\n- send_sms: send SMS\n- send_notification: show notification\n- set_alarm: set alarm\n- ssh_exec: remote command\n- memory_store/memory_recall: persistent memory\n\nDO NOT describe what you would do — actually DO it with tools.\nIf a tool fails, try an alternative. When finished, summarize what was accomplished."
+    val modelId = agent?.model?.ifEmpty { null } ?: provider.selectedModelId
+    val temperature = agent?.temperature ?: 0.7f
 
-      // Build messages
-      val messages = listOf("system" to systemPrompt, "user" to task.prompt)
+    // Build messages
+    val messages = listOf("system" to systemPrompt, "user" to task.prompt)
 
-      // Resolve tools from timer config
-      val timerTools = task.tools.split(",").map { it.trim() }.filter { it.isNotEmpty() }.toSet()
-      val toolDefs = if (timerTools.isNotEmpty()) buildWorkerToolDefs(timerTools) else emptyList()
+    // Resolve tools from timer config
+    val timerTools = task.tools.split(",").map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+    val toolDefs = if (timerTools.isNotEmpty()) buildWorkerToolDefs(timerTools) else emptyList()
 
-      // Create orchestrator with tools
-      val orchestrator = StreamingOrchestrator(
-        baseUrl = provider.effectiveApiBase(),
-        apiKey = provider.apiKey,
-        model = modelId,
-        tools = toolDefs,
-        onToolCall = { name, args -> executeWorkerTool(name, args) },
-        temperature = temperature,
-      )
+    // Create orchestrator with tools
+    val orchestrator = StreamingOrchestrator(
+      baseUrl = provider.effectiveApiBase(),
+      apiKey = provider.apiKey,
+      model = modelId,
+      tools = toolDefs,
+      onToolCall = { name, args -> executeWorkerTool(name, args) },
+      temperature = temperature,
+    )
 
-      // Stream and collect
-      val sb = StringBuilder()
-      orchestrator.stream(messages).collect { chunk ->
-        if (chunk.content.isNotEmpty()) sb.append(chunk.content)
-      }
-
-      sb.toString().ifEmpty { "(no output)" }
-    } catch (e: Exception) {
-      "Error: ${e.message ?: "unknown"}"
+    // Stream and collect
+    val sb = StringBuilder()
+    orchestrator.stream(messages).collect { chunk ->
+      if (chunk.content.isNotEmpty()) sb.append(chunk.content)
     }
+
+    sb.toString().ifEmpty { "(no output)" }
+  } catch (e: Exception) {
+    "Error: ${e.message ?: "unknown"}"
   }
 
   /** Tool definitions available in background worker context */
@@ -174,46 +174,57 @@ class AgentSchedulerWorker(
           val stdoutFuture = java.util.concurrent.CompletableFuture.supplyAsync { proc.inputStream.bufferedReader().readText() }
           val stderrFuture = java.util.concurrent.CompletableFuture.supplyAsync { proc.errorStream.bufferedReader().readText() }
           proc.waitFor(timeout, java.util.concurrent.TimeUnit.MILLISECONDS)
-          if (proc.isAlive) { proc.destroyForcibly(); return (stdoutFuture.get() + stderrFuture.get()).take(4000) + "\n[timeout after ${timeout/1000}s]" }
+          if (proc.isAlive) {
+            proc.destroyForcibly()
+            return (stdoutFuture.get() + stderrFuture.get()).take(4000) + "\n[timeout after ${timeout / 1000}s]"
+          }
           (stdoutFuture.get() + stderrFuture.get()).take(4000)
         }
+
         "read_file" -> {
           val path = args["path"]?.toString() ?: return "Error: no path"
           java.io.File(path).readText().take(8000)
         }
+
         "write_file" -> {
           val path = args["path"]?.toString() ?: return "Error: no path"
           val content = args["content"]?.toString() ?: return "Error: no content"
           java.io.File(path).apply { parentFile?.mkdirs() }.writeText(content)
           "Written to $path"
         }
+
         "list_directory" -> {
           val path = args["path"]?.toString() ?: return "Error: no path"
           java.io.File(path).listFiles()?.joinToString("\n") { (if (it.isDirectory) "d " else "f ") + it.name } ?: "Empty or not found"
         }
+
         "search_web" -> {
           val query = args["query"]?.toString() ?: return "Error: no query"
           val url = "https://search.xnet.ngo/search?q=${java.net.URLEncoder.encode(query, "UTF-8")}&format=json"
           val response = okhttp3.OkHttpClient().newCall(okhttp3.Request.Builder().url(url).build()).execute()
           response.body?.string()?.take(4000) ?: "No results"
         }
+
         "fetch_url" -> {
           val url = args["url"]?.toString() ?: return "Error: no url"
           val response = okhttp3.OkHttpClient().newCall(okhttp3.Request.Builder().url(url).build()).execute()
           response.body?.string()?.take(8000) ?: "Empty response"
         }
+
         "send_sms" -> {
           val to = args["to"]?.toString() ?: return "Error: no recipient"
           val message = args["message"]?.toString() ?: return "Error: no message"
           android.telephony.SmsManager.getDefault().sendTextMessage(to, null, message, null, null)
           "SMS sent to $to"
         }
+
         "send_notification" -> {
           val title = args["title"]?.toString() ?: "Agent"
           val body = args["body"]?.toString() ?: ""
           showNotification(title, body)
           "Notification sent"
         }
+
         "set_alarm" -> {
           val hour = (args["hour"] as? Number)?.toInt() ?: return "Error: no hour"
           val minute = (args["minute"] as? Number)?.toInt() ?: 0
@@ -228,6 +239,7 @@ class AgentSchedulerWorker(
           appContext.startActivity(intent)
           "Alarm set for $hour:${minute.toString().padStart(2, '0')} — $label"
         }
+
         "ssh_exec" -> {
           val host = args["host"]?.toString() ?: return "Error: no host"
           val cmd = args["command"]?.toString() ?: return "Error: no command"
@@ -238,6 +250,7 @@ class AgentSchedulerWorker(
           proc.waitFor()
           (output + err).take(4000)
         }
+
         "memory_store" -> {
           val key = args["key"]?.toString() ?: return "Error: no key"
           val value = args["value"]?.toString() ?: return "Error: no value"
@@ -248,6 +261,7 @@ class AgentSchedulerWorker(
           db.close()
           "Stored: $key"
         }
+
         "memory_recall" -> {
           val query = args["query"]?.toString() ?: return "Error: no query"
           val db = androidx.room.Room.databaseBuilder(appContext, ChatDatabase::class.java, "aiope-chat.db")
@@ -256,9 +270,13 @@ class AgentSchedulerWorker(
           val memories = db.chatDao().getAllMemories()
           db.close()
           val matches = memories.filter { it.key.contains(query, true) || it.content.contains(query, true) }
-          if (matches.isEmpty()) "No memories matching '$query'"
-          else matches.joinToString("\n") { "${it.key}: ${it.content.take(200)}" }
+          if (matches.isEmpty()) {
+            "No memories matching '$query'"
+          } else {
+            matches.joinToString("\n") { "${it.key}: ${it.content.take(200)}" }
+          }
         }
+
         else -> "Tool '$name' not available in background mode"
       }
     } catch (e: Exception) {
@@ -291,6 +309,7 @@ class AgentSchedulerWorker(
         cal.add(Calendar.HOUR_OF_DAY, 1)
         cal.timeInMillis
       }
+
       task.cronDaysOfWeek.isEmpty() -> {
         // Daily: next run tomorrow at cronHour
         cal.add(Calendar.DAY_OF_YEAR, 1)
@@ -298,6 +317,7 @@ class AgentSchedulerWorker(
         cal.set(Calendar.MINUTE, task.cronMinute)
         cal.timeInMillis
       }
+
       else -> {
         // Weekly: next matching day
         cal.add(Calendar.DAY_OF_YEAR, 1)
@@ -319,7 +339,7 @@ class AgentSchedulerWorker(
     val nm = appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       nm.createNotificationChannel(
-        NotificationChannel("agent_timers", "Agent Timers", NotificationManager.IMPORTANCE_DEFAULT)
+        NotificationChannel("agent_timers", "Agent Timers", NotificationManager.IMPORTANCE_DEFAULT),
       )
     }
     val notification = NotificationCompat.Builder(appContext, "agent_timers")
@@ -340,7 +360,7 @@ class AgentSchedulerWorker(
         .setConstraints(
           Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build()
+            .build(),
         )
         .build()
 

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/ImageProcessor.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/ImageProcessor.kt
@@ -25,25 +25,24 @@ object ImageProcessor {
     }.joinToString(",")
   }
 
-  fun encodeImages(filesDir: File, savedPaths: String): List<String> =
-    savedPaths.split(",").filter { it.isNotBlank() }.mapNotNull { relPath ->
-      try {
-        val file = File(filesDir, relPath)
-        if (!file.exists()) return@mapNotNull null
-        val bmp = android.graphics.BitmapFactory.decodeFile(file.absolutePath) ?: return@mapNotNull null
-        val padded = padToSquare(bmp)
-        val scaled = android.graphics.Bitmap.createScaledBitmap(padded, 448, 448, true)
-        if (padded != bmp) padded.recycle()
-        bmp.recycle()
-        val out = java.io.ByteArrayOutputStream()
-        scaled.compress(android.graphics.Bitmap.CompressFormat.JPEG, 85, out)
-        scaled.recycle()
-        android.util.Base64.encodeToString(out.toByteArray(), android.util.Base64.NO_WRAP)
-      } catch (e: Exception) {
-        Log.w("ImageProcessor", "image encode failed: ${e.message}")
-        null
-      }
+  fun encodeImages(filesDir: File, savedPaths: String): List<String> = savedPaths.split(",").filter { it.isNotBlank() }.mapNotNull { relPath ->
+    try {
+      val file = File(filesDir, relPath)
+      if (!file.exists()) return@mapNotNull null
+      val bmp = android.graphics.BitmapFactory.decodeFile(file.absolutePath) ?: return@mapNotNull null
+      val padded = padToSquare(bmp)
+      val scaled = android.graphics.Bitmap.createScaledBitmap(padded, 448, 448, true)
+      if (padded != bmp) padded.recycle()
+      bmp.recycle()
+      val out = java.io.ByteArrayOutputStream()
+      scaled.compress(android.graphics.Bitmap.CompressFormat.JPEG, 85, out)
+      scaled.recycle()
+      android.util.Base64.encodeToString(out.toByteArray(), android.util.Base64.NO_WRAP)
+    } catch (e: Exception) {
+      Log.w("ImageProcessor", "image encode failed: ${e.message}")
+      null
     }
+  }
 
   fun padToSquare(bmp: android.graphics.Bitmap): android.graphics.Bitmap {
     val w = bmp.width

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/PipelineExecutor.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/PipelineExecutor.kt
@@ -115,6 +115,7 @@ class PipelineExecutor(
               else -> emptyList()
             }
           }
+
           is org.json.JSONObject -> {
             name = raw.optString("name", null)
             agent = raw.optString("agent", "default")
@@ -122,6 +123,7 @@ class PipelineExecutor(
             val deps = raw.optJSONArray("depends_on")
             dependsOn = if (deps != null) (0 until deps.length()).mapNotNull { deps.optString(it) } else emptyList()
           }
+
           else -> return@mapNotNull null
         }
 

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/RealtimeAudioManager.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/RealtimeAudioManager.kt
@@ -19,130 +19,152 @@ import org.json.JSONObject
  * RealtimeStreaming owns this and sets the WebSocket after connection.
  */
 class RealtimeAudioManager(
-    private val config: AudioConfig = AudioConfig()
+  private val config: AudioConfig = AudioConfig(),
 ) {
-    private var audioRecord: AudioRecord? = null
-    private var audioTrack: AudioTrack? = null
-    private var captureJob: Job? = null
-    private var playbackJob: Job? = null
-    private var webSocket: WebSocket? = null
-    private var aec: AcousticEchoCanceler? = null
-    private val playbackQueue = java.util.concurrent.LinkedBlockingQueue<ByteArray>()
-    private var sharedSessionId: Int = 0
+  private var audioRecord: AudioRecord? = null
+  private var audioTrack: AudioTrack? = null
+  private var captureJob: Job? = null
+  private var playbackJob: Job? = null
+  private var webSocket: WebSocket? = null
+  private var aec: AcousticEchoCanceler? = null
+  private val playbackQueue = java.util.concurrent.LinkedBlockingQueue<ByteArray>()
+  private var sharedSessionId: Int = 0
 
-    fun setWebSocket(ws: WebSocket) { webSocket = ws }
+  fun setWebSocket(ws: WebSocket) {
+    webSocket = ws
+  }
 
-    /** Start mic capture loop — sends PCM as base64 JSON to the WebSocket */
-    fun startCapture() {
-        // Guard against re-entry: release existing capture resources first
-        if (audioRecord != null) {
-            captureJob?.cancel(); captureJob = null
-            audioRecord?.stop(); audioRecord?.release(); audioRecord = null
-        }
-
-        val bufSize = AudioRecord.getMinBufferSize(
-            config.sampleRate, AudioFormat.CHANNEL_IN_MONO, AudioFormat.ENCODING_PCM_16BIT
-        )
-        if (bufSize <= 0) return
-
-        audioRecord = AudioRecord(
-            MediaRecorder.AudioSource.VOICE_COMMUNICATION,
-            config.sampleRate,
-            AudioFormat.CHANNEL_IN_MONO,
-            AudioFormat.ENCODING_PCM_16BIT,
-            bufSize
-        )
-        if (audioRecord?.state != AudioRecord.STATE_INITIALIZED) {
-            audioRecord?.release(); audioRecord = null; return
-        }
-
-        // Share session ID with AudioTrack for proper AEC pairing
-        sharedSessionId = audioRecord!!.audioSessionId
-
-        // Enable AEC
-        if (AcousticEchoCanceler.isAvailable()) {
-            aec = AcousticEchoCanceler.create(sharedSessionId)
-            aec?.enabled = true
-        }
-
-        // Rebuild AudioTrack with shared session ID for proper AEC pairing
-        if (audioTrack != null && audioTrack?.audioSessionId != sharedSessionId) {
-            playbackJob?.cancel()
-            playbackJob = null
-            audioTrack?.stop()
-            audioTrack?.release()
-            audioTrack = null
-            playbackQueue.clear()
-            startPlayback()
-        }
-
-        audioRecord?.startRecording()
-
-        captureJob = CoroutineScope(Dispatchers.IO).launch {
-            val buf = ByteArray(bufSize)
-            while (isActive) {
-                val read = audioRecord?.read(buf, 0, buf.size) ?: break
-                if (read > 0) {
-                    val encoded = android.util.Base64.encodeToString(buf.copyOf(read), android.util.Base64.NO_WRAP)
-                    webSocket?.send("""{"audio":{"pcm":"$encoded","sampleRate":${config.sampleRate}}}""")
-                }
-            }
-        }
+  /** Start mic capture loop — sends PCM as base64 JSON to the WebSocket */
+  fun startCapture() {
+    // Guard against re-entry: release existing capture resources first
+    if (audioRecord != null) {
+      captureJob?.cancel()
+      captureJob = null
+      audioRecord?.stop()
+      audioRecord?.release()
+      audioRecord = null
     }
 
-    /** Stop mic capture */
-    fun stopCapture() {
-        captureJob?.cancel(); captureJob = null
-        audioRecord?.stop(); audioRecord?.release(); audioRecord = null
+    val bufSize = AudioRecord.getMinBufferSize(
+      config.sampleRate,
+      AudioFormat.CHANNEL_IN_MONO,
+      AudioFormat.ENCODING_PCM_16BIT,
+    )
+    if (bufSize <= 0) return
+
+    audioRecord = AudioRecord(
+      MediaRecorder.AudioSource.VOICE_COMMUNICATION,
+      config.sampleRate,
+      AudioFormat.CHANNEL_IN_MONO,
+      AudioFormat.ENCODING_PCM_16BIT,
+      bufSize,
+    )
+    if (audioRecord?.state != AudioRecord.STATE_INITIALIZED) {
+      audioRecord?.release()
+      audioRecord = null
+      return
     }
 
-    /** Start playback track. If called before startCapture, will be re-initialized with shared session when capture starts. */
-    fun startPlayback(outputRate: Int = 24000) {
-        val bufSize = AudioTrack.getMinBufferSize(
-            outputRate, AudioFormat.CHANNEL_OUT_MONO, AudioFormat.ENCODING_PCM_16BIT
-        )
-        val builder = AudioTrack.Builder()
-            .setAudioAttributes(AudioAttributes.Builder()
-                .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
-                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH).build())
-            .setAudioFormat(AudioFormat.Builder()
-                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
-                .setSampleRate(outputRate)
-                .setChannelMask(AudioFormat.CHANNEL_OUT_MONO).build())
-            .setBufferSizeInBytes(bufSize * 4)
-            .setTransferMode(AudioTrack.MODE_STREAM)
-        if (sharedSessionId != 0) builder.setSessionId(sharedSessionId)
-        audioTrack = builder.build()
-        audioTrack?.play()
+    // Share session ID with AudioTrack for proper AEC pairing
+    sharedSessionId = audioRecord!!.audioSessionId
 
-        // Dedicated playback thread to avoid garbling
-        playbackJob = CoroutineScope(Dispatchers.IO).launch {
-            while (isActive) {
-                val chunk = playbackQueue.poll(100, java.util.concurrent.TimeUnit.MILLISECONDS)
-                if (chunk != null) {
-                    audioTrack?.write(chunk, 0, chunk.size)
-                }
-            }
+    // Enable AEC
+    if (AcousticEchoCanceler.isAvailable()) {
+      aec = AcousticEchoCanceler.create(sharedSessionId)
+      aec?.enabled = true
+    }
+
+    // Rebuild AudioTrack with shared session ID for proper AEC pairing
+    if (audioTrack != null && audioTrack?.audioSessionId != sharedSessionId) {
+      playbackJob?.cancel()
+      playbackJob = null
+      audioTrack?.stop()
+      audioTrack?.release()
+      audioTrack = null
+      playbackQueue.clear()
+      startPlayback()
+    }
+
+    audioRecord?.startRecording()
+
+    captureJob = CoroutineScope(Dispatchers.IO).launch {
+      val buf = ByteArray(bufSize)
+      while (isActive) {
+        val read = audioRecord?.read(buf, 0, buf.size) ?: break
+        if (read > 0) {
+          val encoded = android.util.Base64.encodeToString(buf.copyOf(read), android.util.Base64.NO_WRAP)
+          webSocket?.send("""{"audio":{"pcm":"$encoded","sampleRate":${config.sampleRate}}}""")
         }
+      }
     }
+  }
 
-    /** Queue a PCM chunk for playback */
-    fun playAudio(pcmData: ByteArray) {
-        playbackQueue.offer(pcmData)
-    }
+  /** Stop mic capture */
+  fun stopCapture() {
+    captureJob?.cancel()
+    captureJob = null
+    audioRecord?.stop()
+    audioRecord?.release()
+    audioRecord = null
+  }
 
-    /** Called when model turn completes — flush remaining audio */
-    fun onTurnComplete() {
-        // Let queue drain naturally
-    }
+  /** Start playback track. If called before startCapture, will be re-initialized with shared session when capture starts. */
+  fun startPlayback(outputRate: Int = 24000) {
+    val bufSize = AudioTrack.getMinBufferSize(
+      outputRate,
+      AudioFormat.CHANNEL_OUT_MONO,
+      AudioFormat.ENCODING_PCM_16BIT,
+    )
+    val builder = AudioTrack.Builder()
+      .setAudioAttributes(
+        AudioAttributes.Builder()
+          .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+          .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH).build(),
+      )
+      .setAudioFormat(
+        AudioFormat.Builder()
+          .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+          .setSampleRate(outputRate)
+          .setChannelMask(AudioFormat.CHANNEL_OUT_MONO).build(),
+      )
+      .setBufferSizeInBytes(bufSize * 4)
+      .setTransferMode(AudioTrack.MODE_STREAM)
+    if (sharedSessionId != 0) builder.setSessionId(sharedSessionId)
+    audioTrack = builder.build()
+    audioTrack?.play()
 
-    /** Stop everything */
-    fun stop() {
-        stopCapture()
-        playbackJob?.cancel(); playbackJob = null
-        playbackQueue.clear()
-        aec?.release(); aec = null
-        audioTrack?.stop(); audioTrack?.release(); audioTrack = null
-        webSocket = null
+    // Dedicated playback thread to avoid garbling
+    playbackJob = CoroutineScope(Dispatchers.IO).launch {
+      while (isActive) {
+        val chunk = playbackQueue.poll(100, java.util.concurrent.TimeUnit.MILLISECONDS)
+        if (chunk != null) {
+          audioTrack?.write(chunk, 0, chunk.size)
+        }
+      }
     }
+  }
+
+  /** Queue a PCM chunk for playback */
+  fun playAudio(pcmData: ByteArray) {
+    playbackQueue.offer(pcmData)
+  }
+
+  /** Called when model turn completes — flush remaining audio */
+  fun onTurnComplete() {
+    // Let queue drain naturally
+  }
+
+  /** Stop everything */
+  fun stop() {
+    stopCapture()
+    playbackJob?.cancel()
+    playbackJob = null
+    playbackQueue.clear()
+    aec?.release()
+    aec = null
+    audioTrack?.stop()
+    audioTrack?.release()
+    audioTrack = null
+    webSocket = null
+  }
 }

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/RealtimeStreaming.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/RealtimeStreaming.kt
@@ -1,14 +1,14 @@
 package ngo.xnet.aiope.feature.chat.engine
 
-import ngo.xnet.aiope.core.network.ModelConfig
-import ngo.xnet.aiope.core.network.ModelDef
-import ngo.xnet.aiope.core.network.ProviderProfile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
+import ngo.xnet.aiope.core.network.ModelConfig
+import ngo.xnet.aiope.core.network.ModelDef
+import ngo.xnet.aiope.core.network.ProviderProfile
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -23,129 +23,143 @@ import java.util.Base64
  * Owns the WebSocket and the mic capture loop — emits StreamEvents to the collector.
  */
 class RealtimeStreaming(
-    private val okHttp: OkHttpClient,
-    private val modelDef: ModelDef,
-    private val config: ModelConfig,
-    private val provider: ProviderProfile,
-    private val audioManager: RealtimeAudioManager,
-    private val systemPrompt: String = "",
-    private val voiceName: String = "Aoede",
-    private val gatewayUrl: String = "wss://inf.xnet.ngo/ws/voice"
+  private val okHttp: OkHttpClient,
+  private val modelDef: ModelDef,
+  private val config: ModelConfig,
+  private val provider: ProviderProfile,
+  private val audioManager: RealtimeAudioManager,
+  private val systemPrompt: String = "",
+  private val voiceName: String = "Aoede",
+  private val gatewayUrl: String = "wss://inf.xnet.ngo/ws/voice",
 ) {
-    private var webSocket: WebSocket? = null
+  private var webSocket: WebSocket? = null
 
-    fun createStream(): Flow<StreamEvent> = callbackFlow {
-        val wsUrl = "$gatewayUrl?model=${modelDef.id}"
-        val request = Request.Builder()
-            .url(wsUrl)
-            .addHeader("Authorization", "Bearer ${provider.apiKey}")
-            .build()
+  fun createStream(): Flow<StreamEvent> = callbackFlow {
+    val wsUrl = "$gatewayUrl?model=${modelDef.id}"
+    val request = Request.Builder()
+      .url(wsUrl)
+      .addHeader("Authorization", "Bearer ${provider.apiKey}")
+      .build()
 
-        webSocket = okHttp.newWebSocket(request, object : WebSocketListener() {
-            override fun onOpen(ws: WebSocket, response: Response) {
-                // Send system prompt as first message
-                if (systemPrompt.isNotBlank()) {
-                    val setup = JSONObject().apply {
-                        put("setup", JSONObject().apply {
-                            put("systemPrompt", systemPrompt)
-                            put("voiceName", voiceName)
-                        })
-                    }
-                    ws.send(setup.toString())
-                }
-                trySend(StreamEvent.Connected)
-                // Start mic capture → sends audio over this WS
-                audioManager.setWebSocket(ws)
-                audioManager.startCapture()
+    webSocket = okHttp.newWebSocket(
+      request,
+      object : WebSocketListener() {
+        override fun onOpen(ws: WebSocket, response: Response) {
+          // Send system prompt as first message
+          if (systemPrompt.isNotBlank()) {
+            val setup = JSONObject().apply {
+              put(
+                "setup",
+                JSONObject().apply {
+                  put("systemPrompt", systemPrompt)
+                  put("voiceName", voiceName)
+                },
+              )
             }
-
-            override fun onMessage(ws: WebSocket, text: String) {
-                try {
-                    val json = JSONObject(text)
-
-                    json.optJSONObject("audio")?.optString("pcm")?.let { b64 ->
-                        if (b64.isNotBlank()) {
-                            trySend(StreamEvent.AudioChunk(Base64.getDecoder().decode(b64)))
-                        }
-                    }
-
-                    json.optJSONObject("text")?.optString("delta")?.let {
-                        if (it.isNotBlank()) trySend(StreamEvent.TextDelta(it))
-                    }
-
-                    if (json.has("turnStart")) trySend(StreamEvent.TurnStart(json.optString("turnStart")))
-                    if (json.has("turnComplete")) trySend(StreamEvent.TurnComplete)
-                    if (json.has("inputTranscription")) trySend(StreamEvent.InputTranscription(json.getString("inputTranscription")))
-                    if (json.has("outputTranscription")) trySend(StreamEvent.OutputTranscription(json.getString("outputTranscription")))
-                    if (json.has("toolCall")) {
-                        val tc = json.getJSONObject("toolCall")
-                        val fcs = tc.getJSONArray("functionCalls")
-                        val calls = (0 until fcs.length()).map { i ->
-                            val fc = fcs.getJSONObject(i)
-                            val args = mutableMapOf<String, String>()
-                            fc.optJSONObject("args")?.let { a -> a.keys().forEach { k -> args[k] = a.optString(k, "") } }
-                            FunctionCall(fc.getString("name"), fc.getString("id"), args)
-                        }
-                        trySend(StreamEvent.ToolCallEvent(calls))
-                    }
-                    if (json.has("error")) trySend(StreamEvent.Error(json.getString("error")))
-                } catch (e: Exception) {
-                    trySend(StreamEvent.Error("Parse error: ${e.message}"))
-                }
-            }
-
-            override fun onMessage(ws: WebSocket, bytes: ByteString) {
-                trySend(StreamEvent.AudioChunk(bytes.toByteArray()))
-            }
-
-            override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
-                trySend(StreamEvent.Error(t.message ?: "Connection failed"))
-                close()
-            }
-
-            override fun onClosed(ws: WebSocket, code: Int, reason: String) {
-                trySend(StreamEvent.Disconnected)
-                close()
-            }
-        })
-
-        awaitClose { stop() }
-    }.flowOn(Dispatchers.IO)
-
-    /** Send text mid-conversation (e.g. barge-in or typed input) */
-    fun sendText(text: String) {
-        val json = JSONObject().apply {
-            put("text", JSONObject().apply { put("content", text) })
+            ws.send(setup.toString())
+          }
+          trySend(StreamEvent.Connected)
+          // Start mic capture → sends audio over this WS
+          audioManager.setWebSocket(ws)
+          audioManager.startCapture()
         }
-        webSocket?.send(json.toString())
-    }
 
-    /** Send tool execution results back */
-    fun sendToolResponse(responses: List<Pair<String, String>>) {
-        val json = JSONObject().apply {
-            put("toolResponse", JSONObject().apply {
-                put("functionResponses", org.json.JSONArray().apply {
-                    responses.forEach { (id, result) ->
-                        put(JSONObject().apply {
-                            put("id", id)
-                            put("response", JSONObject().apply { put("result", result) })
-                        })
-                    }
-                })
-            })
+        override fun onMessage(ws: WebSocket, text: String) {
+          try {
+            val json = JSONObject(text)
+
+            json.optJSONObject("audio")?.optString("pcm")?.let { b64 ->
+              if (b64.isNotBlank()) {
+                trySend(StreamEvent.AudioChunk(Base64.getDecoder().decode(b64)))
+              }
+            }
+
+            json.optJSONObject("text")?.optString("delta")?.let {
+              if (it.isNotBlank()) trySend(StreamEvent.TextDelta(it))
+            }
+
+            if (json.has("turnStart")) trySend(StreamEvent.TurnStart(json.optString("turnStart")))
+            if (json.has("turnComplete")) trySend(StreamEvent.TurnComplete)
+            if (json.has("inputTranscription")) trySend(StreamEvent.InputTranscription(json.getString("inputTranscription")))
+            if (json.has("outputTranscription")) trySend(StreamEvent.OutputTranscription(json.getString("outputTranscription")))
+            if (json.has("toolCall")) {
+              val tc = json.getJSONObject("toolCall")
+              val fcs = tc.getJSONArray("functionCalls")
+              val calls = (0 until fcs.length()).map { i ->
+                val fc = fcs.getJSONObject(i)
+                val args = mutableMapOf<String, String>()
+                fc.optJSONObject("args")?.let { a -> a.keys().forEach { k -> args[k] = a.optString(k, "") } }
+                FunctionCall(fc.getString("name"), fc.getString("id"), args)
+              }
+              trySend(StreamEvent.ToolCallEvent(calls))
+            }
+            if (json.has("error")) trySend(StreamEvent.Error(json.getString("error")))
+          } catch (e: Exception) {
+            trySend(StreamEvent.Error("Parse error: ${e.message}"))
+          }
         }
-        webSocket?.send(json.toString())
-    }
 
-    /** Signal end of user turn */
-    fun endTurn() {
-        webSocket?.send("""{"turnEnd":true}""")
-    }
+        override fun onMessage(ws: WebSocket, bytes: ByteString) {
+          trySend(StreamEvent.AudioChunk(bytes.toByteArray()))
+        }
 
-    /** Tear down everything */
-    fun stop() {
-        audioManager.stopCapture()
-        webSocket?.close(1000, "Client ended")
-        webSocket = null
+        override fun onFailure(ws: WebSocket, t: Throwable, response: Response?) {
+          trySend(StreamEvent.Error(t.message ?: "Connection failed"))
+          close()
+        }
+
+        override fun onClosed(ws: WebSocket, code: Int, reason: String) {
+          trySend(StreamEvent.Disconnected)
+          close()
+        }
+      },
+    )
+
+    awaitClose { stop() }
+  }.flowOn(Dispatchers.IO)
+
+  /** Send text mid-conversation (e.g. barge-in or typed input) */
+  fun sendText(text: String) {
+    val json = JSONObject().apply {
+      put("text", JSONObject().apply { put("content", text) })
     }
+    webSocket?.send(json.toString())
+  }
+
+  /** Send tool execution results back */
+  fun sendToolResponse(responses: List<Pair<String, String>>) {
+    val json = JSONObject().apply {
+      put(
+        "toolResponse",
+        JSONObject().apply {
+          put(
+            "functionResponses",
+            org.json.JSONArray().apply {
+              responses.forEach { (id, result) ->
+                put(
+                  JSONObject().apply {
+                    put("id", id)
+                    put("response", JSONObject().apply { put("result", result) })
+                  },
+                )
+              }
+            },
+          )
+        },
+      )
+    }
+    webSocket?.send(json.toString())
+  }
+
+  /** Signal end of user turn */
+  fun endTurn() {
+    webSocket?.send("""{"turnEnd":true}""")
+  }
+
+  /** Tear down everything */
+  fun stop() {
+    audioManager.stopCapture()
+    webSocket?.close(1000, "Client ended")
+    webSocket = null
+  }
 }

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/StreamEvent.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/StreamEvent.kt
@@ -4,22 +4,22 @@ package ngo.xnet.aiope.feature.chat.engine
  * Stream events for realtime voice sessions.
  */
 sealed class StreamEvent {
-    data class TextDelta(val text: String) : StreamEvent()
-    data class AudioChunk(val pcmData: ByteArray) : StreamEvent()
-    data class TurnStart(val turnId: String) : StreamEvent()
-    data object TurnComplete : StreamEvent()
-    data class InputTranscription(val text: String) : StreamEvent()
-    data class OutputTranscription(val text: String) : StreamEvent()
-    data class ToolCallEvent(val functionCalls: List<FunctionCall>) : StreamEvent()
-    data class Error(val message: String) : StreamEvent()
-    data object Connected : StreamEvent()
-    data object Disconnected : StreamEvent()
+  data class TextDelta(val text: String) : StreamEvent()
+  data class AudioChunk(val pcmData: ByteArray) : StreamEvent()
+  data class TurnStart(val turnId: String) : StreamEvent()
+  data object TurnComplete : StreamEvent()
+  data class InputTranscription(val text: String) : StreamEvent()
+  data class OutputTranscription(val text: String) : StreamEvent()
+  data class ToolCallEvent(val functionCalls: List<FunctionCall>) : StreamEvent()
+  data class Error(val message: String) : StreamEvent()
+  data object Connected : StreamEvent()
+  data object Disconnected : StreamEvent()
 }
 
 data class FunctionCall(val name: String, val id: String, val args: Map<String, String>)
 
 data class AudioConfig(
-    val sampleRate: Int = 16000,
-    val channelMask: Int = 1,
-    val encoding: Int = 2,
+  val sampleRate: Int = 16000,
+  val channelMask: Int = 1,
+  val encoding: Int = 2,
 )

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/StreamingOrchestrator.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/StreamingOrchestrator.kt
@@ -441,28 +441,40 @@ class StreamingOrchestrator(
             coroutineScope {
               callInfos.map { call ->
                 async(Dispatchers.IO) {
-                  val result = try { onToolCall(call.name, call.arguments) } catch (e: Exception) { "Error: ${e.message}" }
+                  val result = try {
+                    onToolCall(call.name, call.arguments)
+                  } catch (e: Exception) {
+                    "Error: ${e.message}"
+                  }
                   ToolResultInfo(id = call.id, name = call.name, arguments = call.arguments, result = result)
                 }
               }.map { it.await() }
             }
           } else {
             callInfos.map { call ->
-              val result = try { onToolCall(call.name, call.arguments) } catch (e: Exception) { "Error: ${e.message}" }
+              val result = try {
+                onToolCall(call.name, call.arguments)
+              } catch (e: Exception) {
+                "Error: ${e.message}"
+              }
               ToolResultInfo(id = call.id, name = call.name, arguments = call.arguments, result = result)
             }
           }
           send(ChatStreamChunk(toolResults = results))
-          rawMessages.add(JSONObject().apply {
-            put("role", "assistant")
-            put("content", text)
-          })
+          rawMessages.add(
+            JSONObject().apply {
+              put("role", "assistant")
+              put("content", text)
+            },
+          )
           for (r in results) {
-            rawMessages.add(JSONObject().apply {
-              put("role", "tool")
-              put("tool_call_id", r.id)
-              put("content", r.result.take(16000))
-            })
+            rawMessages.add(
+              JSONObject().apply {
+                put("role", "tool")
+                put("tool_call_id", r.id)
+                put("content", r.result.take(16000))
+              },
+            )
           }
           contentSoFar.clear()
           continue
@@ -524,7 +536,11 @@ class StreamingOrchestrator(
               val key = param.groupValues[1].trim()
               val value = param.groupValues[2].trim()
               // Try to parse as JSON (arrays, objects, numbers, booleans)
-              args[key] = try { JSONObject("{\"v\":$value}").opt("v") } catch (_: Exception) { value }
+              args[key] = try {
+                JSONObject("{\"v\":$value}").opt("v")
+              } catch (_: Exception) {
+                value
+              }
             }
             results.add(name to args)
           }

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/SubagentCard.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/SubagentCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -17,7 +18,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/ToolExecutor.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/ToolExecutor.kt
@@ -5,13 +5,13 @@ import ngo.xnet.aiope.core.model.RemoteToolBridge
 import ngo.xnet.aiope.core.network.ModelTask
 import ngo.xnet.aiope.core.network.ProviderProfile
 import ngo.xnet.aiope.core.network.TaskModelStore
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import ngo.xnet.aiope.feature.chat.LocationData
 import ngo.xnet.aiope.feature.chat.db.ChatDao
 import ngo.xnet.aiope.feature.chat.location.LocationProvider
 import ngo.xnet.aiope.feature.chat.settings.McpManager
 import ngo.xnet.aiope.feature.chat.settings.ProviderStore
 import ngo.xnet.aiope.feature.chat.settings.ToolStore
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 
 class ToolExecutor(
   private val app: Application,
@@ -50,7 +50,7 @@ class ToolExecutor(
       val cloudEmbed = org.xnet.aiope.inference.CloudEmbeddingEngine(
         baseUrl = profile.effectiveApiBase(),
         apiKey = profile.apiKey,
-        model = effectiveModel
+        model = effectiveModel,
       )
       val embedFn: (String) -> FloatArray? = { text -> cloudEmbed.embed(text) }
       ragEngine = org.xnet.aiope.inference.RagEngine(app, embedFn)
@@ -110,7 +110,9 @@ class ToolExecutor(
       // Auto-discover on first use (cache is in-memory, lost on restart)
       try {
         mcpManager.discoverTools(server)
-      } catch (e: Exception) { android.util.Log.w("ToolExec", "op failed: ${e.message}") }
+      } catch (e: Exception) {
+        android.util.Log.w("ToolExec", "op failed: ${e.message}")
+      }
       defs = mcpManager.getToolDefs(server.id)
     }
     defs
@@ -130,7 +132,8 @@ class ToolExecutor(
       val list = (0 until cats.length()).map { cats.getString(it) }.filter { it != "search_web" && it != "image_search" }.joinToString(", ")
       cachedDataCategories = list
       list
-    } catch (e: Exception) { android.util.Log.w("ToolExec", "op failed: ${e.message}")
+    } catch (e: Exception) {
+      android.util.Log.w("ToolExec", "op failed: ${e.message}")
       "air_quality, alerts, apod, asteroids, astronauts, cat, cat_breed, cat_breeds, cme, earth_events, earth_image, earthquakes, earthquakes_significant, epic, fires, geomagnetic, impact_risk, ip_location, iss, nasa_media, nasa_tech, ocean_temp, solar, solar_flares, sunrise_sunset, tides, time, uv, weather, weather_hourly"
     }
   }
@@ -504,15 +507,19 @@ class ToolExecutor(
         "Error: ${e.message}"
       }
 
-
       "rag_search" -> {
         val query = args["query"]?.toString() ?: return "Error: query required"
         val topK = (args["top_k"] as? Number)?.toInt() ?: 5
         try {
           val results = getRagEngine().search(query, topK)
-          if (results.isEmpty()) "No results found in knowledge base."
-          else results.joinToString("\n\n") { "[${String.format("%.2f", it.score)}] ${it.title}\n${it.text}" }
-        } catch (e: Exception) { "RAG error: ${e.message}" }
+          if (results.isEmpty()) {
+            "No results found in knowledge base."
+          } else {
+            results.joinToString("\n\n") { "[${String.format("%.2f", it.score)}] ${it.title}\n${it.text}" }
+          }
+        } catch (e: Exception) {
+          "RAG error: ${e.message}"
+        }
       }
 
       "rag_index" -> {
@@ -521,7 +528,9 @@ class ToolExecutor(
         try {
           val docId = getRagEngine().indexDocument(title, content)
           "Indexed document '$title' (id: $docId)"
-        } catch (e: Exception) { "RAG index error: ${e.message}" }
+        } catch (e: Exception) {
+          "RAG index error: ${e.message}"
+        }
       }
 
       "orchestrate" -> {
@@ -536,7 +545,7 @@ class ToolExecutor(
 
       "ssh_start", "ssh_exec", "ssh_exit" -> {
         val rtp = remoteToolBridge ?: return@execute "Remote tools not available. feature-remote not initialized."
-         rtp.execute(name, args)
+        rtp.execute(name, args)
       }
 
       else -> mcpManager.executeTool(name, args) ?: "Unknown tool: $name"
@@ -585,7 +594,7 @@ class ToolExecutor(
 
     var trimmed = result.substring(safeOffset, end)
     if (end < result.length) {
-       trimmed += "\n...(truncated. Use offset=${end} to read more)"
+      trimmed += "\n...(truncated. Use offset=$end to read more)"
     }
     "Content Length: ${result.length}\nShowing: $safeOffset to $end\n\n$trimmed"
   } catch (e: Exception) {
@@ -603,7 +612,9 @@ class ToolExecutor(
       .build()
     val body = try {
       httpClient.newCall(req).execute().use { if (it.isSuccessful) it.body?.string() ?: "" else "" }
-    } catch (_: Exception) { "" }
+    } catch (_: Exception) {
+      ""
+    }
     if (body.isBlank()) return ddgFallback(query, categories)
     val json = org.json.JSONObject(body)
     val results = json.optJSONArray("results") ?: return ddgFallback(query, categories)
@@ -628,7 +639,9 @@ class ToolExecutor(
       .build()
     val html = try {
       httpClient.newCall(req).execute().use { it.body?.string() ?: "" }
-    } catch (_: Exception) { return "Error: search unavailable" }
+    } catch (_: Exception) {
+      return "Error: search unavailable"
+    }
     val pattern = Regex("""<a rel="nofollow" class="result__a" href="[^"]*uddg=([^&"]+)[^"]*">(.+?)</a>""")
     val snippetPattern = Regex("""<a class="result__snippet"[^>]*>(.+?)</a>""")
     val links = pattern.findAll(html).take(10).toList()
@@ -646,19 +659,23 @@ class ToolExecutor(
 
   private suspend fun executeSearchWeb(query: String): String = try {
     searxQuery(query)
-  } catch (e: Exception) { "Error: ${e.message}" }
+  } catch (e: Exception) {
+    "Error: ${e.message}"
+  }
 
   private suspend fun executeSearchImages(query: String): String = try {
     searxQuery(query, "images")
-  } catch (e: Exception) { "Error: ${e.message}" }
+  } catch (e: Exception) {
+    "Error: ${e.message}"
+  }
 
   private suspend fun executeQueryData(args: Map<String, Any?>): String = try {
     val cat = args["category"]?.toString() ?: ""
     val extra = args["extra"]?.toString() ?: ""
     val needsLoc = cat in setOf("weather", "weather_hourly", "alerts", "air_quality", "uv", "solar", "sunrise_sunset", "time")
     val (lat, lon) = if (needsLoc) {
-      val loc = lastLocationData ?:
-        locationProvider.getLastLocation()?.let { l ->
+      val loc = lastLocationData
+        ?: locationProvider.getLastLocation()?.let { l ->
           lastLocationData = LocationData(l.latitude, l.longitude, null, null, null, l.accuracy.toDouble())
           lastLocationData
         }
@@ -796,7 +813,8 @@ class ToolExecutor(
       } else {
         searchPlaces(query)
       }
-    } catch (e: Exception) { android.util.Log.w("ToolExec", "op failed: ${e.message}")
+    } catch (e: Exception) {
+      android.util.Log.w("ToolExec", "op failed: ${e.message}")
       try {
         searchPlaces(query)
       } catch (e: Exception) {
@@ -832,7 +850,9 @@ class ToolExecutor(
         val body = json.optJSONObject("data")?.toString() ?: raw
         if (body.contains("features")) return parseGeoapifyResults(body, query)
       }
-    } catch (e: Exception) { android.util.Log.w("ToolExec", "op failed: ${e.message}") }
+    } catch (e: Exception) {
+      android.util.Log.w("ToolExec", "op failed: ${e.message}")
+    }
     val apiKey = providerStore.getGeoapifyKey()
     if (apiKey.isBlank()) return "Place search unavailable. Configure location search on the gateway or set a Geoapify key in Settings."
     val conn = httpClient.newCall(okhttp3.Request.Builder().url("https://api.geoapify.com/v2/places?categories=commercial,catering,service,entertainment,leisure,sport,tourism,accommodation,education,healthcare&conditions=named&filter=circle:$lng,$lat,5000&bias=proximity:$lng,$lat&limit=5&name=$encoded&apiKey=$apiKey").build()).execute()
@@ -877,7 +897,8 @@ class ToolExecutor(
     val imgs = mutableListOf<String>()
     extractImageUrls(org.json.JSONTokener(json).nextValue(), imgs)
     if (imgs.isNotEmpty()) imgs.distinct().take(20).joinToString("\n") + "\n\n" + json else json
-  } catch (e: Exception) { android.util.Log.w("ToolExec", "op failed: ${e.message}")
+  } catch (e: Exception) {
+    android.util.Log.w("ToolExec", "op failed: ${e.message}")
     json
   }
 
@@ -898,7 +919,8 @@ class ToolExecutor(
   private fun parseTime(s: String): Long = try {
     val fmts = listOf("yyyy-MM-dd'T'HH:mm", "yyyy-MM-dd HH:mm", "MM/dd/yyyy HH:mm", "MMM d yyyy h:mm a", "h:mm a")
     fmts.firstNotNullOfOrNull { fmt -> runCatching { java.text.SimpleDateFormat(fmt, java.util.Locale.US).parse(s)?.time }.getOrNull() } ?: s.toLong()
-  } catch (e: Exception) { android.util.Log.w("ToolExec", "op failed: ${e.message}")
+  } catch (e: Exception) {
+    android.util.Log.w("ToolExec", "op failed: ${e.message}")
     System.currentTimeMillis() + 3600000
   }
 

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/AgentScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/AgentScreen.kt
@@ -12,9 +12,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
 import ngo.xnet.aiope.feature.chat.db.ChatDao
 import ngo.xnet.aiope.feature.chat.db.SettingsKvEntity
-import kotlinx.coroutines.launch
 
 internal const val AGENT_PROMPT_KEY = "agent_prompt" // kept for migration
 

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/McpManager.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/McpManager.kt
@@ -54,8 +54,7 @@ class McpManager(private val toolStore: ToolStore) {
     }
   }
 
-  private fun sanitizePrefix(name: String): String =
-    name.lowercase().replace(Regex("[^a-z0-9]"), "_").take(16).trimEnd('_')
+  private fun sanitizePrefix(name: String): String = name.lowercase().replace(Regex("[^a-z0-9]"), "_").take(16).trimEnd('_')
 
   fun getCachedTools(serverId: String): List<McpToolMeta> = toolCache[serverId] ?: emptyList()
 

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/McpServerScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/McpServerScreen.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import ngo.xnet.aiope.core.network.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import ngo.xnet.aiope.core.network.*
 
 @Composable
 internal fun McpServerScreen(toolStore: ToolStore, onBack: () -> Unit) {

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ProfileEditorScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ProfileEditorScreen.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import ngo.xnet.aiope.core.network.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import ngo.xnet.aiope.core.network.*
 
 internal val TOKEN_STEPS = listOf(0, 256, 512, 1024, 2048, 4096, 8192, 16000, 32000, 64000, 128000, 200000, 500000, 1000000)
 internal val HISTORY_STEPS = listOf(1000, 2000, 4000, 8000, 16000, 32000, 64000, 128000, 200000, 256000, 384000, 500000, 750000, 1000000, 2000000, 5000000, 10000000)

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ProfileListScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ProfileListScreen.kt
@@ -25,11 +25,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import ngo.xnet.aiope.core.network.*
-import ngo.xnet.aiope.feature.chat.db.ChatDao
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import ngo.xnet.aiope.core.network.*
+import ngo.xnet.aiope.feature.chat.db.ChatDao
 
 @Composable
 internal fun ProfileList(

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ProviderStore.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ProviderStore.kt
@@ -1,6 +1,9 @@
 package ngo.xnet.aiope.feature.chat.settings
 
 import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import ngo.xnet.aiope.core.network.ModelConfig
 import ngo.xnet.aiope.core.network.ModelDef
 import ngo.xnet.aiope.core.network.ProviderProfile
@@ -9,9 +12,6 @@ import ngo.xnet.aiope.feature.chat.db.ChatDao
 import ngo.xnet.aiope.feature.chat.db.ModelCacheEntity
 import ngo.xnet.aiope.feature.chat.db.ProviderEntity
 import ngo.xnet.aiope.feature.chat.db.SettingsKvEntity
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import org.json.JSONArray
 import org.json.JSONObject
 import javax.inject.Inject
@@ -115,7 +115,9 @@ class ProviderStore @Inject constructor(
         runBlocking(Dispatchers.IO) { dao.upsertSetting(SettingsKvEntity("geoapify_key", geoKey)) }
       }
       prefs.edit().clear().apply()
-    } catch (e: Exception) { android.util.Log.w("ProviderStore", "op failed: ${e.message}") }
+    } catch (e: Exception) {
+      android.util.Log.w("ProviderStore", "op failed: ${e.message}")
+    }
   }
 
   fun getAll(): List<ProviderProfile> = runBlocking(Dispatchers.IO) {
@@ -211,7 +213,9 @@ class ProviderStore @Inject constructor(
           )
         }.sortedBy { it.id }
         if (models.isNotEmpty()) saveModelCache(profile.builtinId, models)
-      } catch (e: Exception) { android.util.Log.w("ProviderStore", "op failed: ${e.message}") }
+      } catch (e: Exception) {
+        android.util.Log.w("ProviderStore", "op failed: ${e.message}")
+      }
     }.start()
   }
 }

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/RagScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/RagScreen.kt
@@ -28,312 +28,312 @@ import java.io.File
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun RagScreen(onBack: () -> Unit) {
-    val theme = ngo.xnet.aiope.feature.chat.theme.LocalThemeState.current
-    val scaffoldColor = if (theme.useBackground) androidx.compose.ui.graphics.Color.Transparent else MaterialTheme.colorScheme.background
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
+  val theme = ngo.xnet.aiope.feature.chat.theme.LocalThemeState.current
+  val scaffoldColor = if (theme.useBackground) androidx.compose.ui.graphics.Color.Transparent else MaterialTheme.colorScheme.background
+  val context = LocalContext.current
+  val scope = rememberCoroutineScope()
 
-    var ragEngine by remember { mutableStateOf<RagEngine?>(null) }
-    var documents by remember { mutableStateOf<List<RagEngine.DocumentInfo>>(emptyList()) }
-    var loading by remember { mutableStateOf(true) }
-    var indexing by remember { mutableStateOf(false) }
-    var status by remember { mutableStateOf("") }
-    var showDeleteAllDialog by remember { mutableStateOf(false) }
+  var ragEngine by remember { mutableStateOf<RagEngine?>(null) }
+  var documents by remember { mutableStateOf<List<RagEngine.DocumentInfo>>(emptyList()) }
+  var loading by remember { mutableStateOf(true) }
+  var indexing by remember { mutableStateOf(false) }
+  var status by remember { mutableStateOf("") }
+  var showDeleteAllDialog by remember { mutableStateOf(false) }
 
-    // Initialize RagEngine and load documents
-    LaunchedEffect(Unit) {
-        withContext(Dispatchers.IO) {
-            try {
-                // Resolve RAG embedding model from task config
-                val taskStore = ngo.xnet.aiope.core.network.TaskModelStore(context)
-                val tc = taskStore.getTaskConfig(ngo.xnet.aiope.core.network.ModelTask.RAG)
-                val modelId = tc.modelId ?: "google-ai-studio/models-gemini-embedding-2"
+  // Initialize RagEngine and load documents
+  LaunchedEffect(Unit) {
+    withContext(Dispatchers.IO) {
+      try {
+        // Resolve RAG embedding model from task config
+        val taskStore = ngo.xnet.aiope.core.network.TaskModelStore(context)
+        val tc = taskStore.getTaskConfig(ngo.xnet.aiope.core.network.ModelTask.RAG)
+        val modelId = tc.modelId ?: "google-ai-studio/models-gemini-embedding-2"
 
-                val cloudEmbed = org.xnet.aiope.inference.CloudEmbeddingEngine(
-                    baseUrl = "https://inf.xnet.ngo/v1",
-                    apiKey = ngo.xnet.aiope.feature.chat.BuildConfig.GATEWAY_KEY,
-                    model = modelId
-                )
-                val embedFn: (String) -> FloatArray? = { text -> cloudEmbed.embed(text) }
-
-                val rag = RagEngine(context, embedFn)
-                ragEngine = rag
-                documents = rag.listDocuments()
-            } catch (e: Exception) {
-                status = "Error: ${e.message?.take(60)}"
-            }
-            loading = false
-        }
-    }
-
-    fun refresh() {
-        ragEngine?.let { documents = it.listDocuments() }
-    }
-
-    // File picker for upload
-    val fileLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.GetContent()
-    ) { uri: Uri? ->
-        if (uri != null) {
-            indexing = true
-            status = "Indexing..."
-            scope.launch(Dispatchers.IO) {
-                try {
-                    val name = uri.lastPathSegment?.substringAfterLast('/') ?: "uploaded_file"
-                    val mimeType = context.contentResolver.getType(uri) ?: ""
-                    val text = if (mimeType == "application/pdf" || name.endsWith(".pdf", ignoreCase = true)) {
-                        try {
-                            val bytes = context.contentResolver.openInputStream(uri)?.use { s -> s.readBytes() } ?: byteArrayOf()
-                            com.tom_roush.pdfbox.android.PDFBoxResourceLoader.init(context)
-                            val doc = com.tom_roush.pdfbox.pdmodel.PDDocument.load(bytes)
-                            val extracted = com.tom_roush.pdfbox.text.PDFTextStripper().getText(doc)
-                            doc.close()
-                            extracted
-                        } catch (e: Exception) {
-                            ""
-                        }
-                    } else {
-                        context.contentResolver.openInputStream(uri)?.bufferedReader()?.readText() ?: ""
-                    }
-                    if (text.isBlank()) {
-                        withContext(Dispatchers.Main) { status = "File was empty or unreadable" }
-                    } else {
-                        ragEngine?.indexDocument(title = name, content = text, source = "upload")
-                        withContext(Dispatchers.Main) {
-                            status = "Indexed: $name (${text.length} chars)"
-                            refresh()
-                        }
-                    }
-                } catch (e: Exception) {
-                    withContext(Dispatchers.Main) { status = "Error: ${e.message?.take(60)}" }
-                }
-                withContext(Dispatchers.Main) { indexing = false }
-            }
-        }
-    }
-
-    // Delete all confirmation dialog
-    if (showDeleteAllDialog) {
-        AlertDialog(
-            onDismissRequest = { showDeleteAllDialog = false },
-            title = { Text("Delete All Documents") },
-            text = { Text("This will remove all indexed documents and their embeddings. This cannot be undone.") },
-            confirmButton = {
-                TextButton(onClick = {
-                    showDeleteAllDialog = false
-                    scope.launch(Dispatchers.IO) {
-                        ragEngine?.deleteAllDocuments()
-                        withContext(Dispatchers.Main) {
-                            refresh()
-                            status = "All documents deleted"
-                        }
-                    }
-                }) { Text("Delete All", color = MaterialTheme.colorScheme.error) }
-            },
-            dismissButton = {
-                TextButton(onClick = { showDeleteAllDialog = false }) { Text("Cancel") }
-            }
+        val cloudEmbed = org.xnet.aiope.inference.CloudEmbeddingEngine(
+          baseUrl = "https://inf.xnet.ngo/v1",
+          apiKey = ngo.xnet.aiope.feature.chat.BuildConfig.GATEWAY_KEY,
+          model = modelId,
         )
-    }
+        val embedFn: (String) -> FloatArray? = { text -> cloudEmbed.embed(text) }
 
-    Scaffold(
-        containerColor = scaffoldColor,
-        contentColor = MaterialTheme.colorScheme.onSurface,
-        topBar = {
-            TopAppBar(
-                title = { Text("RAG Documents") },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = if (theme.useBackground) androidx.compose.ui.graphics.Color.Transparent else MaterialTheme.colorScheme.surface
-                ),
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
-                    }
-                },
-                actions = {
-                    IconButton(
-                        onClick = { fileLauncher.launch("*/*") },
-                        enabled = !indexing && !loading
-                    ) {
-                        Icon(Icons.Default.Add, "Upload document")
-                    }
-                    if (documents.isNotEmpty()) {
-                        IconButton(onClick = {
-                            // Reindex all documents with current embedding model
-                            indexing = true
-                            status = "Re-indexing all documents..."
-                            scope.launch(Dispatchers.IO) {
-                                try {
-                                    ragEngine?.reindexAll()
-                                    withContext(Dispatchers.Main) {
-                                        status = "Re-indexed ${documents.size} documents"
-                                        indexing = false
-                                    }
-                                } catch (e: Exception) {
-                                    withContext(Dispatchers.Main) {
-                                        status = "Re-index error: ${e.message?.take(40)}"
-                                        indexing = false
-                                    }
-                                }
-                            }
-                        }, enabled = !indexing) {
-                            Icon(Icons.Default.Refresh, "Re-index all")
-                        }
-                        IconButton(onClick = { showDeleteAllDialog = true }) {
-                            Icon(Icons.Default.Delete, "Delete all")
-                        }
-                    }
-                }
-            )
+        val rag = RagEngine(context, embedFn)
+        ragEngine = rag
+        documents = rag.listDocuments()
+      } catch (e: Exception) {
+        status = "Error: ${e.message?.take(60)}"
+      }
+      loading = false
+    }
+  }
+
+  fun refresh() {
+    ragEngine?.let { documents = it.listDocuments() }
+  }
+
+  // File picker for upload
+  val fileLauncher = rememberLauncherForActivityResult(
+    ActivityResultContracts.GetContent(),
+  ) { uri: Uri? ->
+    if (uri != null) {
+      indexing = true
+      status = "Indexing..."
+      scope.launch(Dispatchers.IO) {
+        try {
+          val name = uri.lastPathSegment?.substringAfterLast('/') ?: "uploaded_file"
+          val mimeType = context.contentResolver.getType(uri) ?: ""
+          val text = if (mimeType == "application/pdf" || name.endsWith(".pdf", ignoreCase = true)) {
+            try {
+              val bytes = context.contentResolver.openInputStream(uri)?.use { s -> s.readBytes() } ?: byteArrayOf()
+              com.tom_roush.pdfbox.android.PDFBoxResourceLoader.init(context)
+              val doc = com.tom_roush.pdfbox.pdmodel.PDDocument.load(bytes)
+              val extracted = com.tom_roush.pdfbox.text.PDFTextStripper().getText(doc)
+              doc.close()
+              extracted
+            } catch (e: Exception) {
+              ""
+            }
+          } else {
+            context.contentResolver.openInputStream(uri)?.bufferedReader()?.readText() ?: ""
+          }
+          if (text.isBlank()) {
+            withContext(Dispatchers.Main) { status = "File was empty or unreadable" }
+          } else {
+            ragEngine?.indexDocument(title = name, content = text, source = "upload")
+            withContext(Dispatchers.Main) {
+              status = "Indexed: $name (${text.length} chars)"
+              refresh()
+            }
+          }
+        } catch (e: Exception) {
+          withContext(Dispatchers.Main) { status = "Error: ${e.message?.take(60)}" }
         }
-    ) { pad ->
-        Column(
-            Modifier
-                .fillMaxSize()
-                .padding(pad)
+        withContext(Dispatchers.Main) { indexing = false }
+      }
+    }
+  }
+
+  // Delete all confirmation dialog
+  if (showDeleteAllDialog) {
+    AlertDialog(
+      onDismissRequest = { showDeleteAllDialog = false },
+      title = { Text("Delete All Documents") },
+      text = { Text("This will remove all indexed documents and their embeddings. This cannot be undone.") },
+      confirmButton = {
+        TextButton(onClick = {
+          showDeleteAllDialog = false
+          scope.launch(Dispatchers.IO) {
+            ragEngine?.deleteAllDocuments()
+            withContext(Dispatchers.Main) {
+              refresh()
+              status = "All documents deleted"
+            }
+          }
+        }) { Text("Delete All", color = MaterialTheme.colorScheme.error) }
+      },
+      dismissButton = {
+        TextButton(onClick = { showDeleteAllDialog = false }) { Text("Cancel") }
+      },
+    )
+  }
+
+  Scaffold(
+    containerColor = scaffoldColor,
+    contentColor = MaterialTheme.colorScheme.onSurface,
+    topBar = {
+      TopAppBar(
+        title = { Text("RAG Documents") },
+        colors = TopAppBarDefaults.topAppBarColors(
+          containerColor = if (theme.useBackground) androidx.compose.ui.graphics.Color.Transparent else MaterialTheme.colorScheme.surface,
+        ),
+        navigationIcon = {
+          IconButton(onClick = onBack) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+          }
+        },
+        actions = {
+          IconButton(
+            onClick = { fileLauncher.launch("*/*") },
+            enabled = !indexing && !loading,
+          ) {
+            Icon(Icons.Default.Add, "Upload document")
+          }
+          if (documents.isNotEmpty()) {
+            IconButton(onClick = {
+              // Reindex all documents with current embedding model
+              indexing = true
+              status = "Re-indexing all documents..."
+              scope.launch(Dispatchers.IO) {
+                try {
+                  ragEngine?.reindexAll()
+                  withContext(Dispatchers.Main) {
+                    status = "Re-indexed ${documents.size} documents"
+                    indexing = false
+                  }
+                } catch (e: Exception) {
+                  withContext(Dispatchers.Main) {
+                    status = "Re-index error: ${e.message?.take(40)}"
+                    indexing = false
+                  }
+                }
+              }
+            }, enabled = !indexing) {
+              Icon(Icons.Default.Refresh, "Re-index all")
+            }
+            IconButton(onClick = { showDeleteAllDialog = true }) {
+              Icon(Icons.Default.Delete, "Delete all")
+            }
+          }
+        },
+      )
+    },
+  ) { pad ->
+    Column(
+      Modifier
+        .fillMaxSize()
+        .padding(pad),
+    ) {
+      // Search bar
+      var searchQuery by remember { mutableStateOf("") }
+      var searchResults by remember { mutableStateOf<List<org.xnet.aiope.inference.RagEngine.SearchResult>>(emptyList()) }
+      var searching by remember { mutableStateOf(false) }
+
+      Row(
+        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        OutlinedTextField(
+          value = searchQuery,
+          onValueChange = { searchQuery = it },
+          label = { Text("Search knowledge base") },
+          modifier = Modifier.weight(1f),
+          singleLine = true,
+        )
+        Spacer(Modifier.width(8.dp))
+        IconButton(
+          onClick = {
+            if (searchQuery.isNotBlank() && ragEngine != null) {
+              searching = true
+              scope.launch(Dispatchers.IO) {
+                val results = ragEngine!!.search(searchQuery, topK = 5)
+                withContext(Dispatchers.Main) {
+                  searchResults = results
+                  searching = false
+                  status = if (results.isEmpty()) "No results" else "${results.size} results"
+                }
+              }
+            }
+          },
+          enabled = !searching && searchQuery.isNotBlank(),
         ) {
-            // Search bar
-            var searchQuery by remember { mutableStateOf("") }
-            var searchResults by remember { mutableStateOf<List<org.xnet.aiope.inference.RagEngine.SearchResult>>(emptyList()) }
-            var searching by remember { mutableStateOf(false) }
-
-            Row(
-                Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                OutlinedTextField(
-                    value = searchQuery,
-                    onValueChange = { searchQuery = it },
-                    label = { Text("Search knowledge base") },
-                    modifier = Modifier.weight(1f),
-                    singleLine = true,
-                )
-                Spacer(Modifier.width(8.dp))
-                IconButton(
-                    onClick = {
-                        if (searchQuery.isNotBlank() && ragEngine != null) {
-                            searching = true
-                            scope.launch(Dispatchers.IO) {
-                                val results = ragEngine!!.search(searchQuery, topK = 5)
-                                withContext(Dispatchers.Main) {
-                                    searchResults = results
-                                    searching = false
-                                    status = if (results.isEmpty()) "No results" else "${results.size} results"
-                                }
-                            }
-                        }
-                    },
-                    enabled = !searching && searchQuery.isNotBlank()
-                ) {
-                    Icon(Icons.Default.Search, "Search")
-                }
-            }
-
-            // Search results
-            if (searchResults.isNotEmpty()) {
-                LazyColumn(Modifier.fillMaxWidth().weight(1f)) {
-                    item {
-                        Text("Search Results", style = MaterialTheme.typography.titleSmall, modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp))
-                    }
-                    items(searchResults.size) { i ->
-                        val r = searchResults[i]
-                        Card(
-                            Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
-                            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
-                        ) {
-                            Column(Modifier.padding(12.dp)) {
-                                Text("[${String.format("%.2f", r.score)}] ${r.title}", style = MaterialTheme.typography.labelMedium, fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
-                                Spacer(Modifier.height(4.dp))
-                                androidx.compose.foundation.text.selection.SelectionContainer {
-                                    Text(r.text, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                                }
-                            }
-                        }
-                    }
-                    item {
-                        TextButton(onClick = { searchResults = emptyList() }, modifier = Modifier.padding(horizontal = 16.dp)) {
-                            Text("Clear results")
-                        }
-                    }
-                }
-            } else {
-            // Status bar
-            if (status.isNotBlank()) {
-                Surface(
-                    color = MaterialTheme.colorScheme.surfaceVariant,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text(
-                        status,
-                        style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                    )
-                }
-            }
-
-            if (loading) {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        CircularProgressIndicator()
-                        Spacer(Modifier.height(8.dp))
-                        Text("Loading RAG engine...", style = MaterialTheme.typography.bodySmall)
-                    }
-                }
-            } else if (indexing) {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        CircularProgressIndicator()
-                        Spacer(Modifier.height(8.dp))
-                        Text("Indexing document...", style = MaterialTheme.typography.bodySmall)
-                    }
-                }
-            } else if (documents.isEmpty()) {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text("No documents indexed", style = MaterialTheme.typography.bodyLarge)
-                        Spacer(Modifier.height(8.dp))
-                        Text(
-                            "Tap + to upload a text file for indexing",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
-                }
-            } else {
-                LazyColumn(Modifier.fillMaxSize()) {
-                    items(documents, key = { it.id }) { doc ->
-                        ListItem(
-                            headlineContent = { Text(doc.title) },
-                            supportingContent = {
-                                Text(
-                                    "${doc.chunkCount} chunks • ${doc.createdAt.take(10)}",
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            },
-                            trailingContent = {
-                                IconButton(onClick = {
-                                    scope.launch(Dispatchers.IO) {
-                                        ragEngine?.deleteDocument(doc.id)
-                                        withContext(Dispatchers.Main) {
-                                            refresh()
-                                            status = "Deleted: ${doc.title}"
-                                        }
-                                    }
-                                }) {
-                                    Icon(
-                                        Icons.Default.Delete,
-                                        contentDescription = "Delete",
-                                        tint = MaterialTheme.colorScheme.error
-                                    )
-                                }
-                            }
-                        )
-                        HorizontalDivider()
-                    }
-                }
-            }
-            } // end else (no search results)
+          Icon(Icons.Default.Search, "Search")
         }
+      }
+
+      // Search results
+      if (searchResults.isNotEmpty()) {
+        LazyColumn(Modifier.fillMaxWidth().weight(1f)) {
+          item {
+            Text("Search Results", style = MaterialTheme.typography.titleSmall, modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp))
+          }
+          items(searchResults.size) { i ->
+            val r = searchResults[i]
+            Card(
+              Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+              colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)),
+            ) {
+              Column(Modifier.padding(12.dp)) {
+                Text("[${String.format("%.2f", r.score)}] ${r.title}", style = MaterialTheme.typography.labelMedium, fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
+                Spacer(Modifier.height(4.dp))
+                androidx.compose.foundation.text.selection.SelectionContainer {
+                  Text(r.text, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+              }
+            }
+          }
+          item {
+            TextButton(onClick = { searchResults = emptyList() }, modifier = Modifier.padding(horizontal = 16.dp)) {
+              Text("Clear results")
+            }
+          }
+        }
+      } else {
+        // Status bar
+        if (status.isNotBlank()) {
+          Surface(
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            modifier = Modifier.fillMaxWidth(),
+          ) {
+            Text(
+              status,
+              style = MaterialTheme.typography.bodySmall,
+              modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+          }
+        }
+
+        if (loading) {
+          Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+              CircularProgressIndicator()
+              Spacer(Modifier.height(8.dp))
+              Text("Loading RAG engine...", style = MaterialTheme.typography.bodySmall)
+            }
+          }
+        } else if (indexing) {
+          Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+              CircularProgressIndicator()
+              Spacer(Modifier.height(8.dp))
+              Text("Indexing document...", style = MaterialTheme.typography.bodySmall)
+            }
+          }
+        } else if (documents.isEmpty()) {
+          Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+              Text("No documents indexed", style = MaterialTheme.typography.bodyLarge)
+              Spacer(Modifier.height(8.dp))
+              Text(
+                "Tap + to upload a text file for indexing",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+              )
+            }
+          }
+        } else {
+          LazyColumn(Modifier.fillMaxSize()) {
+            items(documents, key = { it.id }) { doc ->
+              ListItem(
+                headlineContent = { Text(doc.title) },
+                supportingContent = {
+                  Text(
+                    "${doc.chunkCount} chunks • ${doc.createdAt.take(10)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                  )
+                },
+                trailingContent = {
+                  IconButton(onClick = {
+                    scope.launch(Dispatchers.IO) {
+                      ragEngine?.deleteDocument(doc.id)
+                      withContext(Dispatchers.Main) {
+                        refresh()
+                        status = "Deleted: ${doc.title}"
+                      }
+                    }
+                  }) {
+                    Icon(
+                      Icons.Default.Delete,
+                      contentDescription = "Delete",
+                      tint = MaterialTheme.colorScheme.error,
+                    )
+                  }
+                },
+              )
+              HorizontalDivider()
+            }
+          }
+        }
+      } // end else (no search results)
     }
+  }
 }

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/TaskModelScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/TaskModelScreen.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import ngo.xnet.aiope.core.network.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import ngo.xnet.aiope.core.network.*
 
 @Composable
 internal fun TaskModelScreen(providerStore: ProviderStore, onBack: () -> Unit) {

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ToolStore.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ToolStore.kt
@@ -1,13 +1,13 @@
 package ngo.xnet.aiope.feature.chat.settings
 
 import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import ngo.xnet.aiope.feature.chat.db.ChatDao
 import ngo.xnet.aiope.feature.chat.db.McpServerEntity
 import ngo.xnet.aiope.feature.chat.db.SettingsKvEntity
 import ngo.xnet.aiope.feature.chat.db.ToolToggleEntity
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import org.json.JSONArray
 import org.json.JSONObject
 import javax.inject.Inject

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ToolToggleScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ToolToggleScreen.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import ngo.xnet.aiope.core.network.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import ngo.xnet.aiope.core.network.*
 
 @Composable
 internal fun ToolToggleScreen(toolStore: ToolStore, onBack: () -> Unit) {

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/VoiceSettingsScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/VoiceSettingsScreen.kt
@@ -43,10 +43,8 @@ private val DISPLAY_NAMES = mapOf(
   "Sulafat" to "Sophie",
 )
 
-fun getVoiceName(context: Context): String {
-  return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    .getString(KEY_VOICE, DEFAULT_VOICE) ?: DEFAULT_VOICE
-}
+fun getVoiceName(context: Context): String = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+  .getString(KEY_VOICE, DEFAULT_VOICE) ?: DEFAULT_VOICE
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -66,7 +64,7 @@ fun VoiceSettingsScreen(onBack: () -> Unit) {
         colors = TopAppBarDefaults.topAppBarColors(containerColor = if (theme.useBackground) androidx.compose.ui.graphics.Color.Transparent else MaterialTheme.colorScheme.surface),
         navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back") } },
       )
-    }
+    },
   ) { pad ->
     LazyColumn(Modifier.fillMaxSize().padding(pad).padding(horizontal = 16.dp)) {
       item {

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/FpsCappedRenderersFactory.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/FpsCappedRenderersFactory.kt
@@ -18,37 +18,37 @@ import androidx.media3.exoplayer.video.VideoRendererEventListener
  * substantially without stalling the pipeline or dropping audio sync.
  */
 internal class FpsCappedRenderersFactory(
-    context: Context,
-    private val maxFps: Float,
+  context: Context,
+  private val maxFps: Float,
 ) : DefaultRenderersFactory(context) {
 
-    override fun buildVideoRenderers(
-        context: Context,
-        extensionRendererMode: Int,
-        mediaCodecSelector: MediaCodecSelector,
-        enableDecoderFallback: Boolean,
-        eventHandler: Handler,
-        eventListener: VideoRendererEventListener,
-        allowedVideoJoiningTimeMs: Long,
-        out: ArrayList<Renderer>,
-    ) {
-        // We intentionally add only the capped renderer (no extension renderers):
-        // the background video always uses a hardware codec via MediaCodecSelector.
-        out.add(
-            FpsCappedVideoRenderer(
-                builder = MediaCodecVideoRenderer.Builder(context)
-                    .setMediaCodecSelector(mediaCodecSelector)
-                    .setAllowedJoiningTimeMs(allowedVideoJoiningTimeMs)
-                    .setEnableDecoderFallback(enableDecoderFallback)
-                    .setEventHandler(eventHandler)
-                    .setEventListener(eventListener)
-                    .setMaxDroppedFramesToNotify(
-                        DefaultRenderersFactory.MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY,
-                    ),
-                maxFps = maxFps,
-            ),
-        )
-    }
+  override fun buildVideoRenderers(
+    context: Context,
+    extensionRendererMode: Int,
+    mediaCodecSelector: MediaCodecSelector,
+    enableDecoderFallback: Boolean,
+    eventHandler: Handler,
+    eventListener: VideoRendererEventListener,
+    allowedVideoJoiningTimeMs: Long,
+    out: ArrayList<Renderer>,
+  ) {
+    // We intentionally add only the capped renderer (no extension renderers):
+    // the background video always uses a hardware codec via MediaCodecSelector.
+    out.add(
+      FpsCappedVideoRenderer(
+        builder = MediaCodecVideoRenderer.Builder(context)
+          .setMediaCodecSelector(mediaCodecSelector)
+          .setAllowedJoiningTimeMs(allowedVideoJoiningTimeMs)
+          .setEnableDecoderFallback(enableDecoderFallback)
+          .setEventHandler(eventHandler)
+          .setEventListener(eventListener)
+          .setMaxDroppedFramesToNotify(
+            DefaultRenderersFactory.MAX_DROPPED_VIDEO_FRAME_COUNT_TO_NOTIFY,
+          ),
+        maxFps = maxFps,
+      ),
+    )
+  }
 }
 
 /**
@@ -62,24 +62,24 @@ internal class FpsCappedRenderersFactory(
  * codec never starves.
  */
 internal class FpsCappedVideoRenderer(
-    builder: MediaCodecVideoRenderer.Builder,
-    private val maxFps: Float,
+  builder: MediaCodecVideoRenderer.Builder,
+  private val maxFps: Float,
 ) : MediaCodecVideoRenderer(builder) {
 
-    /** Minimum interval between presented frames, in microseconds. */
-    private val minFrameIntervalUs: Long = (1_000_000L / maxFps).toLong()
+  /** Minimum interval between presented frames, in microseconds. */
+  private val minFrameIntervalUs: Long = (1_000_000L / maxFps).toLong()
 
-    /** Elapsed time of the last presented frame; `Long.MIN_VALUE` = never. */
-    private var lastPresentedElapsedUs: Long = Long.MIN_VALUE
+  /** Elapsed time of the last presented frame; `Long.MIN_VALUE` = never. */
+  private var lastPresentedElapsedUs: Long = Long.MIN_VALUE
 
-    override fun render(positionUs: Long, elapsedRealtimeUs: Long) {
-        if (lastPresentedElapsedUs == Long.MIN_VALUE ||
-            elapsedRealtimeUs - lastPresentedElapsedUs >= minFrameIntervalUs
-        ) {
-            lastPresentedElapsedUs = elapsedRealtimeUs
-            super.render(positionUs, elapsedRealtimeUs)
-        }
-        // else: inside the frame-interval window — skip this pass. The next
-        // pass presents the latest frame and refills the input queue.
+  override fun render(positionUs: Long, elapsedRealtimeUs: Long) {
+    if (lastPresentedElapsedUs == Long.MIN_VALUE ||
+      elapsedRealtimeUs - lastPresentedElapsedUs >= minFrameIntervalUs
+    ) {
+      lastPresentedElapsedUs = elapsedRealtimeUs
+      super.render(positionUs, elapsedRealtimeUs)
     }
+    // else: inside the frame-interval window — skip this pass. The next
+    // pass presents the latest frame and refills the input queue.
+  }
 }

--- a/feature-remote/src/main/kotlin/ngo/xnet/aiope/feature/remote/di/RemoteModule.kt
+++ b/feature-remote/src/main/kotlin/ngo/xnet/aiope/feature/remote/di/RemoteModule.kt
@@ -4,17 +4,17 @@ import android.content.Context
 import androidx.room.Room
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import ngo.xnet.aiope.core.model.RemoteToolBridge
-import ngo.xnet.aiope.feature.remote.db.RemoteDatabase
-import ngo.xnet.aiope.feature.remote.db.RemoteServerDao
-import ngo.xnet.aiope.feature.remote.ssh.SshSessionManager
-import ngo.xnet.aiope.feature.remote.tools.RemoteToolProvider
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import ngo.xnet.aiope.core.model.RemoteToolBridge
+import ngo.xnet.aiope.feature.remote.db.RemoteDatabase
+import ngo.xnet.aiope.feature.remote.db.RemoteServerDao
+import ngo.xnet.aiope.feature.remote.ssh.SshSessionManager
+import ngo.xnet.aiope.feature.remote.tools.RemoteToolProvider
 import javax.inject.Singleton
 
 val MIGRATION_1_2 = object : Migration(1, 2) {

--- a/feature-remote/src/main/kotlin/ngo/xnet/aiope/feature/remote/ssh/DeployUseCase.kt
+++ b/feature-remote/src/main/kotlin/ngo/xnet/aiope/feature/remote/ssh/DeployUseCase.kt
@@ -1,9 +1,9 @@
 package ngo.xnet.aiope.feature.remote.ssh
 
 import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import ngo.xnet.aiope.feature.remote.db.RemoteServerDao
 import ngo.xnet.aiope.feature.remote.db.RemoteServerEntity
-import dagger.hilt.android.qualifiers.ApplicationContext
 import org.json.JSONObject
 import java.io.File
 import java.util.UUID

--- a/feature-remote/src/main/kotlin/ngo/xnet/aiope/feature/remote/ssh/SshSessionManager.kt
+++ b/feature-remote/src/main/kotlin/ngo/xnet/aiope/feature/remote/ssh/SshSessionManager.kt
@@ -1,11 +1,11 @@
 package ngo.xnet.aiope.feature.remote.ssh
 
-import ngo.xnet.aiope.feature.remote.db.RemoteServerEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.common.IOUtils
 import net.schmizz.sshj.xfer.FileSystemFile
+import ngo.xnet.aiope.feature.remote.db.RemoteServerEntity
 import java.security.Security // kept for potential future use
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -92,7 +92,9 @@ class SshSessionManager @Inject constructor() {
       if (existing.isConnected) return@withContext server.id
       // Stale session — disconnect and remove before reconnecting
       sessions.remove(server.id)
-      try { existing.disconnect() } catch (_: Exception) {}
+      try {
+        existing.disconnect()
+      } catch (_: Exception) {}
     }
     val client = SSHClient()
     client.connectTimeout = 15_000
@@ -157,7 +159,11 @@ class SshSessionManager @Inject constructor() {
   fun disconnect(serverId: String) {
     val client = sessions.remove(serverId)
     if (client != null) {
-      Thread { try { client.disconnect() } catch (_: Exception) {} }.start()
+      Thread {
+        try {
+          client.disconnect()
+        } catch (_: Exception) {}
+      }.start()
     }
   }
 

--- a/feature-remote/src/main/kotlin/ngo/xnet/aiope/feature/remote/ui/ServerListViewModel.kt
+++ b/feature-remote/src/main/kotlin/ngo/xnet/aiope/feature/remote/ui/ServerListViewModel.kt
@@ -2,16 +2,16 @@ package ngo.xnet.aiope.feature.remote.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import ngo.xnet.aiope.feature.remote.db.RemoteServerDao
-import ngo.xnet.aiope.feature.remote.db.RemoteServerEntity
-import ngo.xnet.aiope.feature.remote.ssh.DeployUseCase
-import ngo.xnet.aiope.feature.remote.ssh.SshSessionManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import ngo.xnet.aiope.feature.remote.db.RemoteServerDao
+import ngo.xnet.aiope.feature.remote.db.RemoteServerEntity
+import ngo.xnet.aiope.feature.remote.ssh.DeployUseCase
+import ngo.xnet.aiope.feature.remote.ssh.SshSessionManager
 import java.util.UUID
 import javax.inject.Inject
 


### PR DESCRIPTION
## What

Fixes the failing **Spotless check** job in [Android CI run 31518951554](https://github.com/XNet-NGO/aiope/actions/runs/31518951554) — the first CI run on the workflow.

**CI result:** `build` job ✅ passed · `Spotless check` job ❌ failed

## Root cause

The codebase never conformed to the repo's spotless/ktlint config (`indent_size: 2`, ktlint experimental rules). `spotlessCheck` on a fresh checkout fails across 40 files.

## Changes

- **`spotlessApply`** — formatting-only normalization across 40 files (1121 insertions / 889 deletions): 2-space indent, import ordering, trailing whitespace, EOF newline. No semantic changes.
- **`ChatViewModel.kt`** — removed an orphaned `/** ... */` KDoc (from the share/retry rework) that tripped ktlint's error-level `kdoc` rule ("A KDoc is not allowed inside 'class_body'"). This one is not auto-fixable and was blocking `spotlessApply`.

## Verified

- `./gradlew spotlessCheck` → **BUILD SUCCESSFUL**
- `./gradlew :app:compileDebugKotlin` → **BUILD SUCCESSFUL**