### PR TITLE
ci: bump GitHub Actions to v4 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v4
         with:
-          distribution: adopt
+          distribution: temurin
           java-version: 17
       - name: spotless
         run: ./gradlew spotlessCheck
@@ -25,14 +25,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 17
 
-      - uses: gradle/gradle-build-action@v2.7.1
+      - uses: gradle/actions/setup-gradle@v4
       - name: Make Gradle executable
         run: chmod +x ./gradlew
 


### PR DESCRIPTION
## What

Bumps the pinned GitHub Actions to current majors, clearing the Node 20 deprecation annotations from the CI runs.

## Changes

| Action | Before | After | Why |
|---|---|---|---|
| `actions/checkout` | `v3.1.0` / `v3` | `v4` | Node 20 deprecated — v3 forced onto Node 24 |
| `actions/setup-java` | `v3.5.1` / `v3` | `v4` | Same; `adopt` → `temurin` (AdoptOpenJDK EOL) |
| `gradle/gradle-build-action` | `v2.7.1` | `gradle/actions/setup-gradle@v4` | v2 deprecated — action moved to `gradle/actions` |

## Verification

The `pull_request` trigger added in #93 means CI (Spotless check + build) runs automatically against this PR — the v4 actions prove themselves on this very merge candidate.