### PR TITLE
fix(chat): only Build mode unblocks destructive tools

### DIFF
--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/ToolExecutor.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/ToolExecutor.kt
@@ -146,7 +146,7 @@ class ToolExecutor(
   suspend fun execute(name: String, args: Map<String, Any?>): String {
     if (!toolStore.isToolEnabled(name)) return "Tool '$name' is disabled."
     if (name in destructiveTools && getAgentMode() == AgentMode.CHAT) {
-      return "⚠️ Tool '$name' is destructive and blocked in Chat mode. The user must switch to Build mode or enable Auto-Run to allow this action."
+      return "⚠️ Tool '$name' is destructive and blocked in Chat mode. The user must switch to Build mode to allow this action."
     }
     return when (name) {
       "run_sh" -> {


### PR DESCRIPTION
## What

Fixes the tool-blocked message in `ToolExecutor.kt` that told users to **"switch to Build mode or enable Auto-Run"** — implying Auto-Run unlocks destructive tools.

## Reality

Auto-Run only enables autonomous continuation (auto-submitting the next round). Destructive tools (`run_sh`, `write_file`, etc.) are gated solely by **AgentMode** — only **Build mode** unblocks them. Turning on Auto-Run in Chat mode changes nothing about tool access.

## Change

- The user must switch to Build mode or enable Auto-Run to allow this action.
+ The user must switch to Build mode to allow this action.

Verified: this was the only occurrence of the false claim in the repo (grep'd Auto-Run / unblock across kt and md — all other references describe auto-continuation accurately).