### PR TITLE
fix(security): resolve CodeQL high alerts

### DIFF
--- a/core-terminal/src/main/java/ngo/xnet/aiope/core/terminal/backend/TerminalRow.java
+++ b/core-terminal/src/main/java/ngo/xnet/aiope/core/terminal/backend/TerminalRow.java
@@ -214,7 +214,7 @@ public final class TerminalRow {
       // Shift the rest of the line left.
       System.arraycopy(text, oldNextColumnIndex, text, newNextColumnIndex, mSpaceUsed - oldNextColumnIndex);
     }
-    mSpaceUsed += javaCharDifference;
+    mSpaceUsed = (short) (mSpaceUsed + javaCharDifference);
 
     // Store char. A combining character is stored at the end of the existing contents so that it modifies them:
     //noinspection ResultOfMethodCallIgnored - since we already now how many java chars is used.

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/ToolExecutor.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/ToolExecutor.kt
@@ -340,7 +340,7 @@ class ToolExecutor(
           }
           if (cal.timeInMillis <= System.currentTimeMillis()) cal.add(java.util.Calendar.DAY_OF_YEAR, 1)
           val am = app.getSystemService(android.content.Context.ALARM_SERVICE) as android.app.AlarmManager
-          val pi = android.app.PendingIntent.getBroadcast(app, h * 100 + m, android.content.Intent("ngo.xnet.aiope.ALARM"), android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE)
+          val pi = android.app.PendingIntent.getBroadcast(app, h * 100 + m, android.content.Intent("ngo.xnet.aiope.ALARM").setPackage(app.packageName), android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE)
           am.setExactAndAllowWhileIdle(android.app.AlarmManager.RTC_WAKEUP, cal.timeInMillis, pi)
         }
         val h = (args["hour"] as? Number)?.toInt()


### PR DESCRIPTION
Fixes the two HIGH-severity CodeQL alerts from Default setup on main:

| Alert | Rule | Fix |
|---|---|---|
| #5 ToolExecutor.kt:343 | `java/implicit-pendingintents` | Alarm PendingIntent now uses `.setPackage(app.packageName)` — explicit intent, can't be hijacked (FLAG_IMMUTABLE already present) |
| #4 TerminalRow.java:217 | `java/implicit-cast-in-compound-assignment` | `mSpaceUsed = (short) (mSpaceUsed + javaCharDifference)` — explicit narrowing instead of silent implicit cast |

Verified: `:feature-chat:compileDebugKotlin` + `:core-terminal:compileReleaseJavaWithJavac` BUILD SUCCESSFUL.