### PR TITLE
ci: fix release build Metaspace OOM on GitHub runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,15 @@ jobs:
           keyPassword=${{ secrets.KEY_PASSWORD }}
           EOF
 
+      - name: Tune Gradle JVM for runner (prevent OOM)
+        run: |
+          mkdir -p "$HOME/.gradle"
+          cat > "$HOME/.gradle/gradle.properties" <<'EOF'
+          org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=1g -XX:+UseParallelGC
+          kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m
+          org.gradle.workers.max=2
+          EOF
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 


### PR DESCRIPTION
## What

The GitHub Actions release build (`Build & Release APK`) OOMs: `java.lang.OutOfMemoryError: Metaspace` on `RMI TCP Connection(idle)` threads — the daemon wedges, restarts, and the job drags on for 25+ min instead of ~5.

## Root cause

The repo's `gradle.properties` is tuned for the **15 GB build server**:

```
org.gradle.jvmargs=-Xms2048m -Xmx6144m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m ...
```

The GitHub-hosted runner (`ubuntu-latest`) has **7 GB RAM**. Inheriting `-Xmx6144m` (6 GB heap) leaves almost nothing for metaspace + native + the Kotlin daemon, and `-XX:MaxMetaspaceSize=512m` is too small for AGP 9.3 + R8 classloading — so metaspace exhausts and the daemon dies. Exactly the same signature as the recurring `java_pid*.hprof` dumps on the build server (same 512m cap).

## Fix

Write a **CI-only** `gradle.properties` into `GRADLE_USER_HOME` (`~/.gradle/gradle.properties`) before the build — user-home properties take precedence over the project file, so this is scoped to CI and leaves the build server's tuning untouched:

```
org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=1g -XX:+UseParallelGC
kotlin.daemon.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=512m
org.gradle.workers.max=2
```

- 3 GB heap + 1 GB metaspace + Kotlin daemon fits comfortably in 7 GB (no more OOM)
- `workers.max=2` matches the 2-core runner
- No repo `gradle.properties` change → build server behavior unchanged

## Verify

Dispatch the `Build & Release APK` workflow on this branch — the build step should complete in ~5-8 min without the 25+ min wedge. (I'll re-run it once merged.)