### PR TITLE
fix(chat): align task-model preseed with verified defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ Different tasks route to different models automatically:
 |---|---|
 | Chat (primary) | Gemma 4 31B IT (256K context) |
 | Realtime Voice | Gemini 3.1 Flash Live Preview |
-| Subagent | Gemma 4 26B A4B (MoE, 4B active) |
-| Summary | Llama 4 Scout (Pollinations) |
-| Title generation | Nova Fast (Pollinations) |
-| Translation | Nova Fast (Pollinations) |
-| Image recognition | Gemma 4 26B A4B |
-| Image generation | Flux (Pollinations) |
+| Subagent | Gemma 4 31B IT |
+| Summary | Gemma 4 31B IT |
+| Title generation | Gemma 4 26B A4B (MoE) |
+| Translation | Gemma 4 26B A4B (MoE) |
+| Image recognition | Gemma 4 26B A4B (MoE) |
+| Image generation | Flux 1 Schnell (Cloudflare) |
+| RAG Embedding | Gemini Embedding 2 |
 
 All configurable. Any model on any provider for any task.
 

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ProviderStore.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/ProviderStore.kt
@@ -50,9 +50,12 @@ class ProviderStore @Inject constructor(
     }
     seed(ngo.xnet.aiope.core.network.ModelTask.RAG, "google-ai-studio/models-gemini-embedding-2")
     seed(ngo.xnet.aiope.core.network.ModelTask.REALTIME_SPEECH, "google-ai-studio/gemini-3.1-flash-live-preview")
-    seed(ngo.xnet.aiope.core.network.ModelTask.SUMMARY, "google-ai-studio/models-gemma-4-26b-a4b-it")
+    seed(ngo.xnet.aiope.core.network.ModelTask.SUMMARY, "google-ai-studio/models-gemma-4-31b-it")
     seed(ngo.xnet.aiope.core.network.ModelTask.TRANSLATION, "google-ai-studio/models-gemma-4-26b-a4b-it")
     seed(ngo.xnet.aiope.core.network.ModelTask.TITLE, "google-ai-studio/models-gemma-4-26b-a4b-it")
+    seed(ngo.xnet.aiope.core.network.ModelTask.SUBAGENT, "google-ai-studio/models-gemma-4-31b-it")
+    seed(ngo.xnet.aiope.core.network.ModelTask.IMAGE_RECOGNITION, "google-ai-studio/models-gemma-4-26b-a4b-it")
+    seed(ngo.xnet.aiope.core.network.ModelTask.IMAGE_GENERATION, "cloudflare/@cf-black-forest-labs-flux-1-schnell")
   }
 
   private fun seedDefault() {


### PR DESCRIPTION
Device-verified preseed corrections (task_models.xml == ProviderStore seed):

| Task | Old preseed | Correct |
|---|---|---|
| Summary | gemma-4-26b-a4b-it | **gemma-4-31b-it** |
| Subagent | (unseeded) | gemma-4-31b-it |
| Image Recognition | (unseeded) | gemma-4-26b-a4b-it |
| Image Generation | (unseeded) | cloudflare/@cf-black-forest-labs-flux-1-schnell |

RAG/Realtime/Translation/Title were already correct and unchanged. README Models Per Task table fixed to match. Compile verified.