### PR TITLE
feat(theme): custom HSV color pickers for all color options

### DIFF
--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/ColorPickerDialog.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/ColorPickerDialog.kt
@@ -1,6 +1,5 @@
 package ngo.xnet.aiope.feature.chat.theme
 
-import android.graphics.Color as AndroidColor
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -18,8 +17,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -39,8 +40,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.OutlinedTextField
+import android.graphics.Color as AndroidColor
 
 /**
  * Custom color picker.
@@ -101,28 +101,40 @@ fun ColorPickerDialog(
 
         // Saturation slider
         Text("Saturation: ${(sat * 100).toInt()}%", style = MaterialTheme.typography.bodySmall)
-        Slider(value = sat, onValueChange = { sat = it; syncFromHsv() })
+        Slider(value = sat, onValueChange = {
+          sat = it
+          syncFromHsv()
+        })
 
         // Brightness slider
         Text("Brightness: ${(value * 100).toInt()}%", style = MaterialTheme.typography.bodySmall)
-        Slider(value = value, onValueChange = { value = it; syncFromHsv() })
+        Slider(value = value, onValueChange = {
+          value = it
+          syncFromHsv()
+        })
 
         // Hex input
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
           OutlinedTextField(
             value = hex,
-            onValueChange = { hex = it.uppercase(); applyHex(hex) },
+            onValueChange = {
+              hex = it.uppercase()
+              applyHex(hex)
+            },
             singleLine = true,
             label = { Text("Hex") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
             modifier = Modifier.width(140.dp),
           )
-          Text("RGB: ${current.red * 255f}, ${current.green * 255f}, ${current.blue * 255f}".let {
-            val r = (current.red * 255f).toInt()
-            val g = (current.green * 255f).toInt()
-            val b = (current.blue * 255f).toInt()
-            "RGB: $r, $g, $b"
-          }, style = MaterialTheme.typography.bodySmall)
+          Text(
+            "RGB: ${current.red * 255f}, ${current.green * 255f}, ${current.blue * 255f}".let {
+              val r = (current.red * 255f).toInt()
+              val g = (current.green * 255f).toInt()
+              val b = (current.blue * 255f).toInt()
+              "RGB: $r, $g, $b"
+            },
+            style = MaterialTheme.typography.bodySmall,
+          )
         }
       }
     },

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/ColorPickerDialog.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/ColorPickerDialog.kt
@@ -1,0 +1,192 @@
+package ngo.xnet.aiope.feature.chat.theme
+
+import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+
+/**
+ * Custom color picker.
+ * - Hue square: X = hue (0..360), Y = brightness (top = 100%, bottom = 0%)
+ * - Saturation slider, Brightness slider
+ * - Hex input + live preview
+ */
+@Composable
+fun ColorPickerDialog(
+  initialColor: Int,
+  onPick: (Int) -> Unit,
+  onDismiss: () -> Unit,
+) {
+  // Convert initial ARGB to HSV
+  val initHsv = FloatArray(3)
+  AndroidColor.colorToHSV(initialColor, initHsv)
+  var hue by remember { mutableFloatStateOf(initHsv[0]) }
+  var sat by remember { mutableFloatStateOf(initHsv[1]) }
+  var value by remember { mutableFloatStateOf(initHsv[2]) }
+  var hex by remember { mutableStateOf("%06X".format(initialColor and 0xFFFFFF)) }
+
+  fun syncFromHsv() {
+    val c = AndroidColor.HSVToColor(floatArrayOf(hue, sat, value))
+    hex = "%06X".format(c and 0xFFFFFF)
+  }
+
+  val current = Color(AndroidColor.HSVToColor(floatArrayOf(hue, sat, value)))
+
+  fun applyHex(raw: String) {
+    val cleaned = raw.trim().removePrefix("#").uppercase()
+    if (cleaned.length != 6 || !cleaned.all { it.isDigit() || it in 'A'..'F' }) return
+    val rgb = cleaned.toLong(16).toInt()
+    val hsv = FloatArray(3)
+    AndroidColor.colorToHSV(rgb, hsv)
+    hue = hsv[0]
+    sat = hsv[1]
+    value = hsv[2]
+    hex = cleaned
+  }
+
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text("Custom Color") },
+    text = {
+      Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        // Live preview
+        Box(
+          Modifier.fillMaxWidth().height(44.dp).clip(RoundedCornerShape(8.dp))
+            .background(current).border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp)),
+        )
+
+        // Hue square: X = hue, Y = brightness
+        HueSquare(hue = hue, brightness = value, onChange = { h, b ->
+          hue = h
+          value = b
+          syncFromHsv()
+        })
+
+        // Saturation slider
+        Text("Saturation: ${(sat * 100).toInt()}%", style = MaterialTheme.typography.bodySmall)
+        Slider(value = sat, onValueChange = { sat = it; syncFromHsv() })
+
+        // Brightness slider
+        Text("Brightness: ${(value * 100).toInt()}%", style = MaterialTheme.typography.bodySmall)
+        Slider(value = value, onValueChange = { value = it; syncFromHsv() })
+
+        // Hex input
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+          OutlinedTextField(
+            value = hex,
+            onValueChange = { hex = it.uppercase(); applyHex(hex) },
+            singleLine = true,
+            label = { Text("Hex") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+            modifier = Modifier.width(140.dp),
+          )
+          Text("RGB: ${current.red * 255f}, ${current.green * 255f}, ${current.blue * 255f}".let {
+            val r = (current.red * 255f).toInt()
+            val g = (current.green * 255f).toInt()
+            val b = (current.blue * 255f).toInt()
+            "RGB: $r, $g, $b"
+          }, style = MaterialTheme.typography.bodySmall)
+        }
+      }
+    },
+    confirmButton = {
+      TextButton(onClick = { onPick(current.toArgb()) }) { Text("Done") }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismiss) { Text("Cancel") }
+    },
+  )
+}
+
+@Composable
+private fun HueSquare(
+  hue: Float,
+  brightness: Float,
+  onChange: (hue: Float, brightness: Float) -> Unit,
+) {
+  val hueBrush = remember {
+    Brush.horizontalGradient(
+      listOf(
+        Color(AndroidColor.HSVToColor(floatArrayOf(0f, 1f, 1f))),
+        Color(AndroidColor.HSVToColor(floatArrayOf(60f, 1f, 1f))),
+        Color(AndroidColor.HSVToColor(floatArrayOf(120f, 1f, 1f))),
+        Color(AndroidColor.HSVToColor(floatArrayOf(180f, 1f, 1f))),
+        Color(AndroidColor.HSVToColor(floatArrayOf(240f, 1f, 1f))),
+        Color(AndroidColor.HSVToColor(floatArrayOf(300f, 1f, 1f))),
+        Color(AndroidColor.HSVToColor(floatArrayOf(360f, 1f, 1f))),
+      ),
+    )
+  }
+
+  Box(
+    Modifier.fillMaxWidth().height(160.dp).clip(RoundedCornerShape(8.dp))
+      .background(hueBrush)
+      .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp))
+      .pointerInput(hue, brightness) {
+        detectDragGestures { change, _ ->
+          change.consume()
+          val x = (change.position.x / size.width).coerceIn(0f, 1f)
+          val y = (change.position.y / size.height).coerceIn(0f, 1f)
+          onChange(x * 360f, 1f - y)
+        }
+      }
+      .pointerInput(hue, brightness) {
+        detectTapGestures { offset ->
+          val x = (offset.x / size.width).coerceIn(0f, 1f)
+          val y = (offset.y / size.height).coerceIn(0f, 1f)
+          onChange(x * 360f, 1f - y)
+        }
+      },
+  ) {
+    // Brightness overlay (transparent at top -> black at bottom)
+    Canvas(Modifier.fillMaxSize()) {
+      drawRect(Brush.verticalGradient(listOf(Color.Transparent, Color.Black)))
+    }
+    // Current marker
+    val markerX = (hue / 360f).coerceIn(0f, 1f)
+    val markerY = (1f - brightness).coerceIn(0f, 1f)
+    Canvas(Modifier.fillMaxSize()) {
+      val cx = size.width * markerX
+      val cy = size.height * markerY
+      drawCircle(Color.White, radius = 8f, center = Offset(cx, cy))
+      drawCircle(Color.Black, radius = 8f, center = Offset(cx, cy), style = androidx.compose.ui.graphics.drawscope.Stroke(2f))
+    }
+  }
+}

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/ThemeSettingsScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/ThemeSettingsScreen.kt
@@ -40,6 +40,9 @@ fun ThemeSettingsScreen(onBack: () -> Unit) {
   val prefs = remember { ThemePrefs(ctx) }
   val scope = rememberCoroutineScope()
 
+  // Which color picker dialog is open: (key, initialColor)
+  var pickerState by remember { mutableStateOf<Pair<String, Int>?>(null) }
+
   // Collect all state
   val themeMode by prefs.themeMode.collectAsState(initial = "dark")
   val useCustomColors by prefs.useCustomColors.collectAsState(initial = false)
@@ -118,20 +121,28 @@ fun ThemeSettingsScreen(onBack: () -> Unit) {
         // ── Accent Colors ──
         SectionHeader("Accent Colors")
         Text("Primary", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        ColorRow(selected = primaryColor) {
-          scope.launch {
-            prefs.set(ThemePrefs.USE_CUSTOM_COLORS, true)
-            prefs.set(ThemePrefs.PRIMARY_COLOR, it)
-          }
-        }
+        ColorRow(
+          selected = primaryColor,
+          onPick = {
+            scope.launch {
+              prefs.set(ThemePrefs.USE_CUSTOM_COLORS, true)
+              prefs.set(ThemePrefs.PRIMARY_COLOR, it)
+            }
+          },
+          onCustom = { pickerState = "primary" to (primaryColor ?: 0xFF2979FF.toInt()) },
+        )
         Spacer(Modifier.height(4.dp))
         Text("Secondary", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        ColorRow(selected = secondaryColor) {
-          scope.launch {
-            prefs.set(ThemePrefs.USE_CUSTOM_COLORS, true)
-            prefs.set(ThemePrefs.SECONDARY_COLOR, it)
-          }
-        }
+        ColorRow(
+          selected = secondaryColor,
+          onPick = {
+            scope.launch {
+              prefs.set(ThemePrefs.USE_CUSTOM_COLORS, true)
+              prefs.set(ThemePrefs.SECONDARY_COLOR, it)
+            }
+          },
+          onCustom = { pickerState = "secondary" to (secondaryColor ?: 0xFF651FFF.toInt()) },
+        )
 
         HorizontalDivider(Modifier.padding(vertical = 4.dp))
 
@@ -139,15 +150,27 @@ fun ThemeSettingsScreen(onBack: () -> Unit) {
         SectionHeader("UI Color")
         ToggleRow("Custom UI color", useUiColor) { scope.launch { prefs.set(ThemePrefs.USE_UI_COLOR, it) } }
         if (useUiColor) {
-          ColorRow(selected = uiColor) { scope.launch { prefs.set(ThemePrefs.UI_COLOR, it) } }
+          ColorRow(
+            selected = uiColor,
+            onPick = { scope.launch { prefs.set(ThemePrefs.UI_COLOR, it) } },
+            onCustom = { pickerState = "ui" to (uiColor ?: 0xFF2979FF.toInt()) },
+          )
         }
         Spacer(Modifier.height(4.dp))
         ToggleRow("Custom text colors", useCustomText) { scope.launch { prefs.set(ThemePrefs.USE_CUSTOM_TEXT, it) } }
         if (useCustomText) {
           Text("Primary text", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-          ColorRow(selected = primaryTextColor) { scope.launch { prefs.set(ThemePrefs.PRIMARY_TEXT_COLOR, it) } }
+          ColorRow(
+            selected = primaryTextColor,
+            onPick = { scope.launch { prefs.set(ThemePrefs.PRIMARY_TEXT_COLOR, it) } },
+            onCustom = { pickerState = "primaryText" to (primaryTextColor ?: 0xFFFFFFFF.toInt()) },
+          )
           Text("Secondary text", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-          ColorRow(selected = secondaryTextColor) { scope.launch { prefs.set(ThemePrefs.SECONDARY_TEXT_COLOR, it) } }
+          ColorRow(
+            selected = secondaryTextColor,
+            onPick = { scope.launch { prefs.set(ThemePrefs.SECONDARY_TEXT_COLOR, it) } },
+            onCustom = { pickerState = "secondaryText" to (secondaryTextColor ?: 0xFFFFFFFF.toInt()) },
+          )
         }
 
         HorizontalDivider(Modifier.padding(vertical = 4.dp))
@@ -157,17 +180,37 @@ fun ThemeSettingsScreen(onBack: () -> Unit) {
         ToggleRow("Custom bubble colors", useCustomBubbles) { scope.launch { prefs.set(ThemePrefs.USE_CUSTOM_BUBBLES, it) } }
         if (useCustomBubbles) {
           Text("User bubble", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-          ColorRow(selected = userBubbleColor) { scope.launch { prefs.set(ThemePrefs.USER_BUBBLE_COLOR, it) } }
+          ColorRow(
+            selected = userBubbleColor,
+            onPick = { scope.launch { prefs.set(ThemePrefs.USER_BUBBLE_COLOR, it) } },
+            onCustom = { pickerState = "userBubble" to (userBubbleColor ?: 0xFF2979FF.toInt()) },
+          )
           Text("User text", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-          ColorRow(selected = userTextColor) { scope.launch { prefs.set(ThemePrefs.USER_TEXT_COLOR, it) } }
+          ColorRow(
+            selected = userTextColor,
+            onPick = { scope.launch { prefs.set(ThemePrefs.USER_TEXT_COLOR, it) } },
+            onCustom = { pickerState = "userText" to (userTextColor ?: 0xFFFFFFFF.toInt()) },
+          )
           Spacer(Modifier.height(4.dp))
           Text("AI bubble", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-          ColorRow(selected = aiBubbleColor) { scope.launch { prefs.set(ThemePrefs.AI_BUBBLE_COLOR, it) } }
+          ColorRow(
+            selected = aiBubbleColor,
+            onPick = { scope.launch { prefs.set(ThemePrefs.AI_BUBBLE_COLOR, it) } },
+            onCustom = { pickerState = "aiBubble" to (aiBubbleColor ?: 0xFF37474F.toInt()) },
+          )
           Spacer(Modifier.height(4.dp))
           Text("Agent report bubble", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-          ColorRow(selected = agentReportBubbleColor) { scope.launch { prefs.set(ThemePrefs.AGENT_REPORT_BUBBLE_COLOR, it) } }
+          ColorRow(
+            selected = agentReportBubbleColor,
+            onPick = { scope.launch { prefs.set(ThemePrefs.AGENT_REPORT_BUBBLE_COLOR, it) } },
+            onCustom = { pickerState = "agentReport" to (agentReportBubbleColor ?: 0xFF1A237E.toInt()) },
+          )
           Text("AI text", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-          ColorRow(selected = aiTextColor) { scope.launch { prefs.set(ThemePrefs.AI_TEXT_COLOR, it) } }
+          ColorRow(
+            selected = aiTextColor,
+            onPick = { scope.launch { prefs.set(ThemePrefs.AI_TEXT_COLOR, it) } },
+            onCustom = { pickerState = "aiText" to (aiTextColor ?: 0xFFFFFFFF.toInt()) },
+          )
           Spacer(Modifier.height(4.dp))
           Text("User bubble opacity: ${(userBubbleOpacity * 100).toInt()}%", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
           Slider(value = userBubbleOpacity, onValueChange = { scope.launch { prefs.set(ThemePrefs.USER_BUBBLE_OPACITY, it) } }, valueRange = 0.05f..1f)
@@ -224,6 +267,35 @@ fun ThemeSettingsScreen(onBack: () -> Unit) {
       Spacer(Modifier.height(24.dp))
     }
   }
+
+  // ── Custom color picker dialog (any color row) ──
+  pickerState?.let { (key, initial) ->
+    ColorPickerDialog(
+      initialColor = initial,
+      onPick = { color ->
+        when (key) {
+          "primary" -> scope.launch {
+            prefs.set(ThemePrefs.USE_CUSTOM_COLORS, true)
+            prefs.set(ThemePrefs.PRIMARY_COLOR, color)
+          }
+          "secondary" -> scope.launch {
+            prefs.set(ThemePrefs.USE_CUSTOM_COLORS, true)
+            prefs.set(ThemePrefs.SECONDARY_COLOR, color)
+          }
+          "ui" -> scope.launch { prefs.set(ThemePrefs.UI_COLOR, color) }
+          "primaryText" -> scope.launch { prefs.set(ThemePrefs.PRIMARY_TEXT_COLOR, color) }
+          "secondaryText" -> scope.launch { prefs.set(ThemePrefs.SECONDARY_TEXT_COLOR, color) }
+          "userBubble" -> scope.launch { prefs.set(ThemePrefs.USER_BUBBLE_COLOR, color) }
+          "userText" -> scope.launch { prefs.set(ThemePrefs.USER_TEXT_COLOR, color) }
+          "aiBubble" -> scope.launch { prefs.set(ThemePrefs.AI_BUBBLE_COLOR, color) }
+          "agentReport" -> scope.launch { prefs.set(ThemePrefs.AGENT_REPORT_BUBBLE_COLOR, color) }
+          "aiText" -> scope.launch { prefs.set(ThemePrefs.AI_TEXT_COLOR, color) }
+        }
+        pickerState = null
+      },
+      onDismiss = { pickerState = null },
+    )
+  }
 }
 
 @Composable
@@ -240,8 +312,8 @@ private fun ToggleRow(label: String, checked: Boolean, onToggle: (Boolean) -> Un
 }
 
 @Composable
-private fun ColorRow(selected: Int?, onPick: (Int) -> Unit) {
-  Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.horizontalScroll(rememberScrollState())) {
+private fun ColorRow(selected: Int?, onPick: (Int) -> Unit, onCustom: () -> Unit) {
+  Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically, modifier = Modifier.horizontalScroll(rememberScrollState())) {
     PRESET_COLORS.forEach { c ->
       val color = Color(c.toInt() or 0xFF000000.toInt())
       val isSelected = selected == color.toArgb()
@@ -250,6 +322,17 @@ private fun ColorRow(selected: Int?, onPick: (Int) -> Unit) {
           .border(if (isSelected) 2.dp else 0.5.dp, if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant, CircleShape)
           .clickable { onPick(color.toArgb()) },
       )
+    }
+    // Custom picker chip — highlighted when the current selection isn't one of the presets
+    val isCustom = selected != null && PRESET_COLORS.none { Color(it.toInt() or 0xFF000000.toInt()).toArgb() == selected }
+    Box(
+      Modifier.size(32.dp).clip(CircleShape)
+        .background(MaterialTheme.colorScheme.surfaceVariant)
+        .border(if (isCustom) 2.dp else 1.dp, if (isCustom) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant, CircleShape)
+        .clickable(onClick = onCustom),
+      contentAlignment = Alignment.Center,
+    ) {
+      Text("+", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 18.sp)
     }
   }
 }

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/ThemeSettingsScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/ThemeSettingsScreen.kt
@@ -278,17 +278,26 @@ fun ThemeSettingsScreen(onBack: () -> Unit) {
             prefs.set(ThemePrefs.USE_CUSTOM_COLORS, true)
             prefs.set(ThemePrefs.PRIMARY_COLOR, color)
           }
+
           "secondary" -> scope.launch {
             prefs.set(ThemePrefs.USE_CUSTOM_COLORS, true)
             prefs.set(ThemePrefs.SECONDARY_COLOR, color)
           }
+
           "ui" -> scope.launch { prefs.set(ThemePrefs.UI_COLOR, color) }
+
           "primaryText" -> scope.launch { prefs.set(ThemePrefs.PRIMARY_TEXT_COLOR, color) }
+
           "secondaryText" -> scope.launch { prefs.set(ThemePrefs.SECONDARY_TEXT_COLOR, color) }
+
           "userBubble" -> scope.launch { prefs.set(ThemePrefs.USER_BUBBLE_COLOR, color) }
+
           "userText" -> scope.launch { prefs.set(ThemePrefs.USER_TEXT_COLOR, color) }
+
           "aiBubble" -> scope.launch { prefs.set(ThemePrefs.AI_BUBBLE_COLOR, color) }
+
           "agentReport" -> scope.launch { prefs.set(ThemePrefs.AGENT_REPORT_BUBBLE_COLOR, color) }
+
           "aiText" -> scope.launch { prefs.set(ThemePrefs.AI_TEXT_COLOR, color) }
         }
         pickerState = null


### PR DESCRIPTION
## What

Adds a full custom color picker to **every** color option in the Theme settings — no more being stuck with the 11 presets.

## How it works

New `ColorPickerDialog` composable:
- **Hue square**: X axis = hue (0–360°), Y axis = brightness (top = 100%, bottom = 0%), with a live marker
- **Saturation slider** — adjusts S
- **Brightness slider** — adjusts V
- **Hex input** with validation + live **preview swatch** + RGB readout
- Drag or tap the square; sliders update the color in real time

Every `ColorRow` (10 color options total) gains a **`+` chip** at the end of the preset swatches that opens the picker seeded with the current value. When a custom (non-preset) color is selected, the `+` chip gets a primary ring so you can see at a glance that it's customized.

## Color options now covered

| Section | Options |
|---|---|
| Accent | Primary, Secondary |
| UI | UI color, Primary text, Secondary text |
| Bubbles | User bubble, User text, AI bubble, AI text, Agent report bubble |

Pickers write to the **same `ThemePrefs` keys** the presets already write — zero plumbing changes in `ThemeProvider`, the layering logic (custom accent → surface → text) works unchanged.

## Files

- `feature-chat/.../theme/ColorPickerDialog.kt` — new (177 lines)
- `feature-chat/.../theme/ThemeSettingsScreen.kt` — +75 lines (picker state, `onCustom` per row, `+` chip)

## Verified

- `:feature-chat:compileDebugKotlin` — **BUILD SUCCESSFUL**