### PR TITLE
Fix alpha in hex→HSV conversion & simplify RGB display text

### DIFF
--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/ColorPickerDialog.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/theme/ColorPickerDialog.kt
@@ -72,9 +72,10 @@ fun ColorPickerDialog(
   fun applyHex(raw: String) {
     val cleaned = raw.trim().removePrefix("#").uppercase()
     if (cleaned.length != 6 || !cleaned.all { it.isDigit() || it in 'A'..'F' }) return
-    val rgb = cleaned.toLong(16).toInt()
+    // Build a full ARGB int (alpha = FF) so colorToHSV always sees valid channels
+    val argb = (0xFF000000L or cleaned.toLong(16)).toInt()
     val hsv = FloatArray(3)
-    AndroidColor.colorToHSV(rgb, hsv)
+    AndroidColor.colorToHSV(argb, hsv)
     hue = hsv[0]
     sat = hsv[1]
     value = hsv[2]
@@ -127,12 +128,7 @@ fun ColorPickerDialog(
             modifier = Modifier.width(140.dp),
           )
           Text(
-            "RGB: ${current.red * 255f}, ${current.green * 255f}, ${current.blue * 255f}".let {
-              val r = (current.red * 255f).toInt()
-              val g = (current.green * 255f).toInt()
-              val b = (current.blue * 255f).toInt()
-              "RGB: $r, $g, $b"
-            },
+            "RGB: ${(current.red * 255f).toInt()}, ${(current.green * 255f).toInt()}, ${(current.blue * 255f).toInt()}",
             style = MaterialTheme.typography.bodySmall,
           )
         }


### PR DESCRIPTION
Fixes the two review comments from #102:

1. **Alpha channel missing in hex→HSV conversion** — `applyHex` parsed the hex to an `Int` with no alpha bits set (alpha = 0). It now builds a full ARGB value with `(0xFF000000L or cleaned.toLong(16)).toInt()` so `colorToHSV` always operates on valid channels.

2. **Redundant RGB display text** — the readout wrapped a string in `.let { }` that rebuilt and discarded the first string. Simplified to format the channels inline: `"RGB: ${(current.red * 255f).toInt()}, ..."`.

`spotlessApply` clean, `:feature-chat:compileDebugKotlin` passes.