### PR TITLE
feat: recurring timers carry context across runs (up to 60)

### DIFF
--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/AgentPanel.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/AgentPanel.kt
@@ -480,6 +480,14 @@ private fun TimerRow(timer: ScheduledTaskEntity, onEdit: () -> Unit, onDelete: (
           append("${timer.cronHour}:${timer.cronMinute.toString().padStart(2, '0')}")
         }
         if (timer.cronDaysOfWeek.isNotEmpty()) append(" (${timer.cronDaysOfWeek})")
+        if (!timer.oneShot) {
+          if (timer.maxRuns > 0) {
+            append("  ·  ${timer.runsCompleted}/${timer.maxRuns} runs")
+          } else if (timer.runsCompleted > 0) {
+            append("  ·  ran ${timer.runsCompleted}x")
+          }
+          if (!timer.enabled && timer.maxRuns > 0 && timer.runsCompleted >= timer.maxRuns) append("  ·  finished")
+        }
       }
       Text(schedule, fontSize = 9.sp, color = Color(0xFF555555), fontFamily = FontFamily.Monospace)
     }
@@ -511,6 +519,7 @@ private fun AddTimerDialog(agents: List<AgentEntity> = emptyList(), editing: Sch
   var second by remember { mutableIntStateOf(0) }
   var selectedDays by remember { mutableStateOf(editing?.cronDaysOfWeek ?: "") }
   var selectedMonth by remember { mutableIntStateOf(-1) }
+  var maxRuns by remember { mutableIntStateOf(editing?.maxRuns ?: 0) }
 
   AlertDialog(
     onDismissRequest = onDismiss,
@@ -606,6 +615,15 @@ private fun AddTimerDialog(agents: List<AgentEntity> = emptyList(), editing: Sch
             }
           }
         }
+
+        // Max runs (recurring only; 0 = unlimited)
+        if (preset != "once") {
+          Text("Max runs", fontSize = 10.sp, color = Color(0xFF888888))
+          Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+            NumberRoller(value = maxRuns, range = 0..99, label = "Runs", onValueChange = { maxRuns = it })
+            Text(if (maxRuns == 0) "0 = unlimited" else "auto-disables after $maxRuns runs", fontSize = 9.sp, color = Color(0xFF666666))
+          }
+        }
       }
     },
     confirmButton = {
@@ -625,6 +643,8 @@ private fun AddTimerDialog(agents: List<AgentEntity> = emptyList(), editing: Sch
               cronMinute = minute,
               cronDaysOfWeek = if (preset == "weekly") selectedDays else "",
               oneShot = preset == "once",
+              maxRuns = maxRuns,
+              runsCompleted = editing?.runsCompleted ?: 0,
               nextRun = if (preset == "once") System.currentTimeMillis() + 60_000L else null,
             ),
           )

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/db/ChatDatabase.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/db/ChatDatabase.kt
@@ -108,6 +108,19 @@ data class ScheduledTaskEntity(
   val lastRun: Long? = null,
   val nextRun: Long? = null,
   val createdAt: Long = System.currentTimeMillis(),
+  val runsCompleted: Int = 0, // completed runs (recurring timers)
+  val maxRuns: Int = 0, // 0 = unlimited, else auto-disable after N runs
+)
+
+@Entity(tableName = "task_runs")
+data class TaskRunEntity(
+  @PrimaryKey(autoGenerate = true) val id: Long = 0,
+  val scheduledTaskId: String,
+  val runNumber: Int,
+  val timestamp: Long = System.currentTimeMillis(),
+  val prompt: String = "",
+  val output: String = "",
+  val status: String = "success",
 )
 
 @Dao
@@ -252,6 +265,15 @@ interface ChatDao {
 
   @Query("DELETE FROM scheduled_tasks WHERE id = :id")
   suspend fun deleteScheduledTask(id: String)
+
+  @Query("SELECT * FROM task_runs WHERE scheduledTaskId = :taskId ORDER BY runNumber DESC LIMIT :limit")
+  suspend fun getTaskRuns(taskId: String, limit: Int = 5): List<TaskRunEntity>
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun insertTaskRun(run: TaskRunEntity)
+
+  @Query("DELETE FROM task_runs WHERE scheduledTaskId = :taskId")
+  suspend fun deleteTaskRuns(taskId: String)
 }
 
 @Database(
@@ -260,8 +282,9 @@ interface ChatDao {
     ProviderEntity::class, ToolToggleEntity::class, McpServerEntity::class,
     ModelCacheEntity::class, SettingsKvEntity::class,
     AgentEntity::class, AgentTaskEntity::class, ScheduledTaskEntity::class,
+    TaskRunEntity::class,
   ],
-  version = 7,
+  version = 8,
 )
 abstract class ChatDatabase : RoomDatabase() {
   abstract fun chatDao(): ChatDao

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/di/ChatModule.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/di/ChatModule.kt
@@ -55,6 +55,14 @@ val MIGRATION_5_6 = object : Migration(5, 6) {
   }
 }
 
+val MIGRATION_7_8 = object : Migration(7, 8) {
+  override fun migrate(db: SupportSQLiteDatabase) {
+    db.execSQL("ALTER TABLE scheduled_tasks ADD COLUMN runsCompleted INTEGER NOT NULL DEFAULT 0")
+    db.execSQL("ALTER TABLE scheduled_tasks ADD COLUMN maxRuns INTEGER NOT NULL DEFAULT 0")
+    db.execSQL("CREATE TABLE IF NOT EXISTS task_runs (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, scheduledTaskId TEXT NOT NULL, runNumber INTEGER NOT NULL, timestamp INTEGER NOT NULL, prompt TEXT NOT NULL, output TEXT NOT NULL, status TEXT NOT NULL)")
+  }
+}
+
 val MIGRATION_6_7 = object : Migration(6, 7) {
   override fun migrate(db: SupportSQLiteDatabase) {
     db.execSQL("ALTER TABLE scheduled_tasks ADD COLUMN tools TEXT NOT NULL DEFAULT ''")
@@ -68,7 +76,7 @@ object ChatModule {
   @Singleton
   fun provideDatabase(@ApplicationContext ctx: Context): ChatDatabase {
     val db = Room.databaseBuilder(ctx, ChatDatabase::class.java, "aiope-chat.db")
-      .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7)
+      .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
       .addCallback(object : androidx.room.RoomDatabase.Callback() {
         override fun onCreate(db: SupportSQLiteDatabase) { /* seeded in open */ }
         override fun onOpen(db: SupportSQLiteDatabase) {

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/AgentSchedulerWorker.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/AgentSchedulerWorker.kt
@@ -74,9 +74,13 @@ class AgentSchedulerWorker(
           dao.insertScheduledTask(task.copy(enabled = false, lastRun = now, nextRun = null))
         }
 
+        // Recurring runs carry context: this run number + last 5 previous outputs
+        val runNumber = task.runsCompleted + 1
+        val prevRuns = dao.getTaskRuns(task.id, 5)
+
         // Actually run the agent via gateway
         val result = if (provider != null) {
-          runAgent(dao, provider, task)
+          runAgent(dao, provider, task, runNumber, prevRuns)
         } else {
           "Error: No active provider configured"
         }
@@ -84,6 +88,32 @@ class AgentSchedulerWorker(
         // Store result and mark finished
         val status = if (result.startsWith("Error:")) "failed" else "finished"
         dao.updateAgentTask(taskId, status, result, System.currentTimeMillis())
+
+        // Log this run for future context carry-over (truncate output)
+        dao.insertTaskRun(
+          ngo.xnet.aiope.feature.chat.db.TaskRunEntity(
+            scheduledTaskId = task.id,
+            runNumber = runNumber,
+            timestamp = System.currentTimeMillis(),
+            prompt = task.prompt,
+            output = result.take(4000),
+            status = status,
+          ),
+        )
+
+        // Advance progress; auto-disable at maxRuns (0 = unlimited)
+        val maxedOut = !task.oneShot && task.maxRuns > 0 && runNumber >= task.maxRuns
+        if (task.oneShot || maxedOut) {
+          dao.insertScheduledTask(task.copy(enabled = false, lastRun = now, nextRun = null, runsCompleted = runNumber))
+          if (maxedOut) {
+            showNotification(
+              title = "Agent: ${task.agentName} — finished",
+              body = "Completed $runNumber/${task.maxRuns} runs.",
+            )
+          }
+        } else if (!task.oneShot) {
+          dao.insertScheduledTask(task.copy(runsCompleted = runNumber, lastRun = now, nextRun = nextRun))
+        }
 
         // Post notification with result preview
         showNotification(
@@ -104,16 +134,37 @@ class AgentSchedulerWorker(
     dao: ngo.xnet.aiope.feature.chat.db.ChatDao,
     provider: ProviderProfile,
     task: ScheduledTaskEntity,
+    runNumber: Int,
+    prevRuns: List<ngo.xnet.aiope.feature.chat.db.TaskRunEntity>,
   ): String = try {
     // Resolve agent config
     val agent: AgentEntity? = dao.getAgentByName(task.agentName)
     val basePrompt = agent?.prompt ?: "You are a scheduled task agent. Complete the assigned task using your tools."
-    val systemPrompt = basePrompt + "\n\n## Environment\n- Date/Time: " + java.time.ZonedDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("EEEE, yyyy-MM-dd HH:mm:ss z")) + "\n- Platform: Android (AIOPE scheduled task)\n- Execution: Background (WorkManager)\n\n## Tool Execution\nYou MUST use tools to complete your task.\n- search_web: search the web\n- fetch_url: fetch URL content\n- read_file/write_file/list_directory: filesystem\n- run_sh: shell commands\n- send_sms: send SMS\n- send_notification: show notification\n- set_alarm: set alarm\n- ssh_exec: remote command\n- memory_store/memory_recall: persistent memory\n\nDO NOT describe what you would do — actually DO it with tools.\nIf a tool fails, try an alternative. When finished, summarize what was accomplished."
+    val systemPrompt = basePrompt + "\n\n## Environment\n- Date/Time: " + java.time.ZonedDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("EEEE, yyyy-MM-dd HH:mm:ss z")) + "\n- Platform: Android (AIOPE scheduled task)\n- Execution: Background (WorkManager)\n\n## Tool Execution\nYou MUST use tools to complete your task.\n- search_web: search the web\n- fetch_url: fetch URL content\n- read_file/write_file/list_directory: filesystem\n- run_sh: shell commands\n- send_sms: send SMS\n- send_notification: show notification\n- set_alarm: set alarm\n- ssh_exec: remote command\n- memory_store/memory_recall: persistent memory\n\nDO NOT describe what you would do — actually DO it with tools.\nIf a tool fails, try an alternative. When finished, summarize what was accomplished.\nIf this is a recurring run (run # > 1), the previous run outputs are listed in the user message — compare against them and report what CHANGED since the last run."
     val modelId = agent?.model?.ifEmpty { null } ?: provider.selectedModelId
     val temperature = agent?.temperature ?: 0.7f
 
+    // Build user message with run context (previous outputs = carry-over state)
+    val userMessage = buildString {
+      append(task.prompt)
+      append("\n\n## Run Context\n")
+      append("- This is run #").append(runNumber)
+      if (task.maxRuns > 0) append(" of ").append(task.maxRuns)
+      append(".\n")
+      if (prevRuns.isEmpty()) {
+        append("- No previous runs yet — this is the first execution.\n")
+      } else {
+        append("- Previous runs (most recent last):\n")
+        prevRuns.sortedBy { it.runNumber }.forEach { run ->
+          append("  - Run #").append(run.runNumber)
+          append(" (").append(run.status).append("): ")
+          append(run.output.take(600).replace("\n", " ")).append("\n")
+        }
+      }
+    }
+
     // Build messages
-    val messages = listOf("system" to systemPrompt, "user" to task.prompt)
+    val messages = listOf("system" to systemPrompt, "user" to userMessage)
 
     // Resolve tools from timer config
     val timerTools = task.tools.split(",").map { it.trim() }.filter { it.isNotEmpty() }.toSet()


### PR DESCRIPTION
## What

Recurring timers now **remember their own history** instead of re-running the same cold prompt forever.

### Context carry-over
- New `task_runs` table (Room migration 7→8) logs every run: run number, timestamp, prompt, output (truncated to 4k), status
- Worker injects a `## Run Context` section into the user message on every run:
  - "This is run #N of M"
  - Last **5** previous run outputs (oldest→newest), truncated to 600 chars each
- System prompt now tells recurring agents: *compare against previous outputs and report what CHANGED since the last run*

This means "watch the build and report" can now notice the build has been red for 3 runs — run N sees runs N-5..N-1 as its own baseline.

### Run cap (the "up to 60" guard)
- `maxRuns` / `runsCompleted` columns on `scheduled_tasks` (0 = unlimited)
- Worker increments per run; at `maxRuns` the timer **auto-disables** and posts a completion notification ("Completed 12/60 runs")
- No runaway API spend — recurring runs are bounded unless the user chooses unlimited

### UI
- Timer edit dialog: **Max runs** NumberRoller for recurring presets (0 = unlimited, default)
- Timer row shows live progress: `3/60 runs`, `ran 5x`, `· finished`

## Why last-5, not full history
- Bounded context: 5 × 4k ≈ 20k chars fits every model window, no extra summarization LLM call
- Previous outputs **are** the state for a recurring task; agents needing deep state already have `memory_store`/`memory_recall` tools
- 60-run cap matches the user's request and prevents unbounded spend

## Files
- `ChatDatabase.kt` — `TaskRunEntity`, DAO (`getTaskRuns`/`insertTaskRun`/`deleteTaskRuns`), new columns, version 8
- `ChatModule.kt` — `MIGRATION_7_8`
- `AgentSchedulerWorker.kt` — run context injection, run logging, cap check
- `AgentPanel.kt` — max-runs roller + progress badge

Verified: `:feature-chat:compileDebugKotlin` green, `spotlessCheck` green.