### PR TITLE
Fix tool results echoing in reply body

### DIFF
--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatViewModel.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatViewModel.kt
@@ -681,14 +681,10 @@ class ChatViewModel @Inject constructor(
           }
           if (role != null) {
             var content = msg.content
-            // Append tool call summaries so the model recalls what tools it ran
+            // Append tool call names (not results) so the model recalls what tools it ran
             if (role == "assistant" && msg.toolCalls.isNotEmpty()) {
-              val toolSummary = msg.toolCalls.mapIndexed { i, call ->
-                val result = msg.toolResults.getOrNull(i)?.take(500)?.replace('\n', ' ') ?: "(no result)"
-                val name = call.substringBefore("(").substringBefore(" ").trim()
-                "$name → $result"
-              }.joinToString(" | ")
-              content = "[Tools: $toolSummary]\n$content"
+              val toolNames = msg.toolCalls.map { it.substringBefore("(").substringBefore(" ").trim() }.joinToString(", ")
+              content = "[used: $toolNames]\n$content"
             }
             trimmed.add(0, role to content)
           }
@@ -1144,12 +1140,8 @@ $transcript
             Role.ASSISTANT -> {
               var content = msg.content
               if (msg.toolCalls.isNotEmpty()) {
-                val toolSummary = msg.toolCalls.mapIndexed { i, call ->
-                  val result = msg.toolResults.getOrNull(i)?.take(500)?.replace('\n', ' ') ?: "(no result)"
-                  val name = call.substringBefore("(").substringBefore(" ").trim()
-                  "$name → $result"
-                }.joinToString(" | ")
-                content = "[Tools: $toolSummary]\n$content"
+                val toolNames = msg.toolCalls.map { it.substringBefore("(").substringBefore(" ").trim() }.joinToString(", ")
+                content = "[used: $toolNames]\n$content"
               }
               chatMessages.add("assistant" to content)
             }

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/TaskModelScreen.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/settings/TaskModelScreen.kt
@@ -281,7 +281,11 @@ internal suspend fun fetchModels(baseUrl: String, apiKey: String): List<ModelDef
     }
 
     if (resp.responseCode !in 200..299) {
-      val err = try { resp.errorStream?.bufferedReader()?.readText()?.take(200) } catch (_: Exception) { null }
+      val err = try {
+        resp.errorStream?.bufferedReader()?.readText()?.take(200)
+      } catch (_: Exception) {
+        null
+      }
       android.util.Log.e("FetchModels", "HTTP ${resp.responseCode}: $err (url=$url)")
       return@withContext emptyList()
     }


### PR DESCRIPTION
## Problem
Raw tool output (JSON with stdout, exit_code, stderr) was appearing in the assistant's reply text. Models were echoing back the `[Tools: ssh_exec → {"stdout":...}]` context prefix.

## Root cause
History messages included full tool results (up to 500 chars of raw JSON per call) prepended as `[Tools: name → result | name → result]`. Models treated this as part of the conversation format and repeated it.

## Fix
Changed the history prefix from full results to just tool names: `[used: ssh_exec, read_file]`. The model still knows which tools it used (for continuity) without seeing raw output it might parrot back.

Tool results remain visible in the ToolTabStrip UI and are properly sent via the tool_calls/tool message format during the active streaming round.