### PR TITLE
fix: SSE keepalive for cellular NAT + broken bcpkix dep

### DIFF
--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/KeepAliveSocketFactory.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/KeepAliveSocketFactory.kt
@@ -1,0 +1,24 @@
+package ngo.xnet.aiope.feature.chat.engine
+
+import java.net.InetAddress
+import java.net.Socket
+import javax.net.SocketFactory
+
+/**
+ * Socket factory that enables TCP keepalive on all connections.
+ * Prevents NAT timeout drops on cellular networks during long SSE streams
+ * where the server may be silent for 30-60s while generating a response.
+ */
+object KeepAliveSocketFactory : SocketFactory() {
+  private val default = getDefault()
+
+  override fun createSocket(): Socket = default.createSocket().apply { keepAlive = true }
+
+  override fun createSocket(host: String, port: Int): Socket = default.createSocket(host, port).apply { keepAlive = true }
+
+  override fun createSocket(host: String, port: Int, localHost: InetAddress, localPort: Int): Socket = default.createSocket(host, port, localHost, localPort).apply { keepAlive = true }
+
+  override fun createSocket(host: InetAddress, port: Int): Socket = default.createSocket(host, port).apply { keepAlive = true }
+
+  override fun createSocket(address: InetAddress, port: Int, localAddress: InetAddress, localPort: Int): Socket = default.createSocket(address, port, localAddress, localPort).apply { keepAlive = true }
+}

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/StreamingOrchestrator.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/StreamingOrchestrator.kt
@@ -34,12 +34,13 @@ class StreamingOrchestrator(
   companion object {
     private val client = SafeOkHttp.builder()
       .connectTimeout(15, TimeUnit.SECONDS)
-      .readTimeout(5, TimeUnit.MINUTES) // reduced from 10m — detect dead connections faster
+      .readTimeout(3, TimeUnit.MINUTES) // shorter than 5m — trigger retry on dead connections sooner
       .writeTimeout(30, TimeUnit.SECONDS)
       .callTimeout(0, TimeUnit.SECONDS)
       .retryOnConnectionFailure(true)
       .protocols(listOf(okhttp3.Protocol.HTTP_1_1))
       .connectionPool(okhttp3.ConnectionPool(0, 1, TimeUnit.SECONDS)) // no pooling — fresh connection every request (cellular NAT kills idle)
+      .socketFactory(KeepAliveSocketFactory)
       .eventListenerFactory(LlmEventListener.Factory)
       .build()
     private val JSON_MT = "application/json; charset=utf-8".toMediaType()

--- a/feature-remote/build.gradle.kts
+++ b/feature-remote/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
   implementation("com.hierynomus:sshj:0.39.0")
   implementation("org.bouncycastle:bcprov-jdk18on:1.85.2")
-  implementation("org.bouncycastle:bcpkix-jdk18on:1.85.2")
+  implementation("org.bouncycastle:bcpkix-jdk18on:1.85")
 
   implementation(libs.kotlinx.coroutines.android)
 }


### PR DESCRIPTION
## Problem
SSE connections drop during long model generation (30-60s silence) on cellular networks due to NAT timeout. Also, the dependabot bcpkix bump broke the build.

## Fix
1. **TCP keepalive** — `KeepAliveSocketFactory` enables `SO_KEEPALIVE` on all OkHttp sockets. OS sends TCP keepalive probes during silence, keeping NAT tables alive.
2. **Read timeout reduced** — 5min → 3min. Still allows long generation but triggers retry sooner on truly dead connections.
3. **bcpkix version fix** — `bcpkix-jdk18on:1.85.2` doesn't exist on Maven Central. Reverted to 1.85 (only `bcprov` has 1.85.2).

## Notes
- TCP keepalive interval is OS-controlled (Android default ~75s) which fits under most NAT timeouts (60-120s)
- This is provider-agnostic — helps with all upstream APIs
- The real solution for providers with very long thinking pauses would be server-side SSE comments as heartbeats, but we can't control that