### PR TITLE
fix: MiniMax M2.5 tool call rendering

### DIFF
--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatViewModel.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/ChatViewModel.kt
@@ -682,11 +682,6 @@ class ChatViewModel @Inject constructor(
           }
           if (role != null) {
             var content = msg.content
-            // Append tool call names (not results) so the model recalls what tools it ran
-            if (role == "assistant" && msg.toolCalls.isNotEmpty()) {
-              val toolNames = msg.toolCalls.map { it.substringBefore("(").substringBefore(" ").trim() }.joinToString(", ")
-              content = "[used: $toolNames]\n$content"
-            }
             trimmed.add(0, role to content)
           }
         }
@@ -1150,12 +1145,7 @@ $transcript
             Role.USER -> chatMessages.add("user" to msg.content)
 
             Role.ASSISTANT -> {
-              var content = msg.content
-              if (msg.toolCalls.isNotEmpty()) {
-                val toolNames = msg.toolCalls.map { it.substringBefore("(").substringBefore(" ").trim() }.joinToString(", ")
-                content = "[used: $toolNames]\n$content"
-              }
-              chatMessages.add("assistant" to content)
+              chatMessages.add("assistant" to msg.content)
             }
 
             else -> {}

--- a/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/StreamingOrchestrator.kt
+++ b/feature-chat/src/main/kotlin/ngo/xnet/aiope/feature/chat/engine/StreamingOrchestrator.kt
@@ -279,6 +279,13 @@ class StreamingOrchestrator(
                   if (contentSoFar.length > 2_000_000) {
                     contentSoFar.delete(0, contentSoFar.length - 1_500_000)
                   }
+                  // Suppress display of minimax tool call XML (will be parsed after stream)
+                  val soFar = contentSoFar.toString()
+                  if (soFar.contains("<minimax:tool_call>") && !soFar.contains("</minimax:tool_call>")) {
+                    content = "" // Hold back — still accumulating tool call block
+                  } else if (soFar.contains("<minimax:tool_call>") && soFar.contains("</minimax:tool_call>")) {
+                    content = "" // Entire block received — will be handled by fallback parser
+                  }
                 }
 
                 // On retry, skip emitting content we already sent to the UI
@@ -302,7 +309,7 @@ class StreamingOrchestrator(
                   }
                 }
 
-                if (finishReason == "tool_calls" || (finishReason == "stop" && toolAcc.isNotEmpty())) {
+                if (finishReason == "tool_calls" || finishReason == "tool_use" || (finishReason == "stop" && toolAcc.isNotEmpty())) {
                   hasToolCalls = toolAcc.isNotEmpty()
                 }
               } catch (e: Exception) {


### PR DESCRIPTION
MiniMax M2.5 outputs tool calls as XML text (`<minimax:tool_call>`) in the content stream rather than structured `tool_calls` in the delta. This XML was rendering raw in the chat before the fallback parser could catch it.

Fix: detect the tag during streaming and suppress content display while inside the block. The fallback parser then handles it after the stream completes, strips the markup, and renders proper tool chips.